### PR TITLE
Made ViewBuilder.Create with props overload more strongly typed.

### DIFF
--- a/src/Avalonia.FuncUI/Builder.fs
+++ b/src/Avalonia.FuncUI/Builder.fs
@@ -216,13 +216,22 @@ type AttrBuilder<'view>() =
 [<AbstractClass; Sealed>] 
 type ViewBuilder() =
    
-    static member Create<'view>(attrs: IAttr<'view> list, constructorParams: obj array) : IView<'view> =
+    /// Creates a host control with user defined constructor props.
+    static member Create<'view, 'props>(attrs: IAttr<'view> list, createView: 'props -> 'view, props: 'props) : IView<'view> =
         {
             View.viewType = typeof<'view>
-            View.viewConstructorParams = constructorParams
+            View.createView = createView >> Utils.cast<IControl>
+            View.viewConstructorParams = props
             View.attrs = attrs
         }
         :> IView<'view>
         
+    /// Creates a host control.
     static member Create<'view>(attrs: IAttr<'view> list) : IView<'view> =
-        ViewBuilder.Create(attrs, null)
+        {
+            View.viewType = typeof<'view>
+            View.createView = (fun () -> Activator.CreateInstance<'view>()) >> Utils.cast<IControl>
+            View.viewConstructorParams = ()
+            View.attrs = attrs
+        }
+        :> IView<'view>

--- a/src/Avalonia.FuncUI/Types.fs
+++ b/src/Avalonia.FuncUI/Types.fs
@@ -132,27 +132,30 @@ module Types =
 
     type IView =
         abstract member ViewType: Type with get
-        abstract member ViewConstructorParams: obj array with get
+        abstract member ViewConstructorParams: obj
+        abstract member CreateView: (obj -> IControl) with get
         abstract member Attrs: IAttr list with get
         
-    type IView<'viewType> =
+    type IView<'view> =
         inherit IView
-        abstract member Attrs: IAttr<'viewType> list with get
+        abstract member Attrs: IAttr<'view> list with get
         
-    type View<'viewType> =
+    type View<'view, 'props> =
         {
             viewType: Type
-            viewConstructorParams: obj array
-            attrs: IAttr<'viewType> list
+            createView: 'props -> IControl
+            viewConstructorParams: 'props
+            attrs: IAttr<'view> list
         }
         
         interface IView with
             member this.ViewType = this.viewType
-            member this.ViewConstructorParams = this.viewConstructorParams
+            member this.ViewConstructorParams = this.viewConstructorParams |> box
+            member this.CreateView = (fun o -> (o :?> 'props) |> this.createView)
             member this.Attrs =
                 this.attrs |> List.map (fun attr -> attr :> IAttr)
             
-        interface IView<'viewType> with
+        interface IView<'view> with
             member this.Attrs = this.attrs
 
     

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Delta.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Delta.fs
@@ -105,7 +105,8 @@ module internal rec Delta =
     type ViewDelta =
         {
             viewType: Type
-            viewConstructorParams: obj array
+            viewConstructorParams: obj
+            createView: obj -> Avalonia.Controls.IControl
             attrs: AttrDelta list
             reinstantiate: bool
         }
@@ -114,6 +115,7 @@ module internal rec Delta =
                 {
                     viewType = view.ViewType
                     viewConstructorParams = view.ViewConstructorParams
+                    createView    = view.CreateView
                     attrs = view.Attrs |> List.map AttrDelta.From
                     reinstantiate = false
                 }

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Differ.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Differ.fs
@@ -148,6 +148,7 @@ module internal rec Differ =
                     ViewDelta.viewType = next.ViewType
                     ViewDelta.attrs = diffAttributes last.Attrs next.Attrs
                     ViewDelta.viewConstructorParams = next.ViewConstructorParams
+                    ViewDelta.createView = next.CreateView
                     ViewDelta.reinstantiate = false
                 }
                 
@@ -157,6 +158,7 @@ module internal rec Differ =
                     ViewDelta.viewType = next.ViewType
                     ViewDelta.attrs = List.map AttrDelta.From next.Attrs
                     ViewDelta.viewConstructorParams = next.ViewConstructorParams
+                    ViewDelta.createView = next.CreateView
                     ViewDelta.reinstantiate = last.ViewConstructorParams <> next.ViewConstructorParams
                 }
         else

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Patcher.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Patcher.fs
@@ -211,16 +211,8 @@ module internal rec Patcher =
 
     let create (viewElement: ViewDelta) : IControl =
         let control =
-            match viewElement.viewConstructorParams with
-            | null ->
-                viewElement.viewType
-                |> Activator.CreateInstance
-                |> Utils.cast<IControl>
-                
-            | constructorParams ->
-                (viewElement.viewType, constructorParams)
-                |> Activator.CreateInstance
-                |> Utils.cast<IControl>
+            viewElement.viewConstructorParams
+            |> viewElement.createView
 
         control.SetValue(ViewMetaData.ViewIdProperty, Guid.NewGuid())
         Patcher.patch (control, viewElement)

--- a/src/Examples/Examples.ViewBuilderProps/Shell.fs
+++ b/src/Examples/Examples.ViewBuilderProps/Shell.fs
@@ -65,7 +65,7 @@ module Shell =
                                   TabItem.content (Counter.view state.counterState (CounterMsg >> dispatch)) ]
                             TabItem.create [
                                   TabItem.header "Form"
-                                  TabItem.content (ViewBuilder.Create<Form.Host>([], [| formProps |])) ]
+                                  TabItem.content (ViewBuilder.Create([], Form.Host, formProps)) ]
                             ]
                       ]
                 ]


### PR DESCRIPTION
My goal here was to make ViewBuilder.Create more strongly typed with regards to the ctor props that are passed.

```
TabItem.content (ViewBuilder.Create([], Form.Host, formProps)) ]
```