### PR TITLE
Automate package publication via GitHub Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Build, Test and Publish release
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+    - name: Build & Test
+      run: dotnet test src/Avalonia.FuncUI.sln --verbosity normal
+    - name: Build for release
+      run: dotnet build src/Avalonia.FuncUI.sln -c Release
+    - name: Publish base project, DSL and Elmish NuGets (if this version was not published before)
+      run: |
+        dotnet nuget push src/**/bin/Release/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,5 +20,4 @@ jobs:
     - name: Build for release
       run: dotnet build src/Avalonia.FuncUI.sln -c Release
     - name: Publish base project, DSL and Elmish NuGets (if this version was not published before)
-      run: |
-        dotnet nuget push src/**/bin/Release/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+      run: dotnet nuget push src/**/bin/Release/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,8 +1,6 @@
-name: Build
+name: Build and test
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
This PR closes #178 by creating a new workflow called `Build, Test and Publish release` which builds the library, runs all the UTs and publishes a new version to NuGet if the version has changed. Also took the opportunity to rename the old flow to `pull-request.yml` and `Build and test` and make it run only on new PRs to master. 

Heavily inspired by [FSharp.Data's flow](https://github.com/fsprojects/FSharp.Data/blob/main/.github/workflows/push-master.yml) and using the secret name that @dsyme provided in [here](https://github.com/fsprojects/Avalonia.FuncUI/issues/172#issuecomment-988945425). Validated with [Act](https://github.com/nektos/act).