### PR TITLE
add funcui templates

### DIFF
--- a/src/Avalonia.FuncUI.Templates/Avalonia.FuncUI.Templates.fsproj
+++ b/src/Avalonia.FuncUI.Templates/Avalonia.FuncUI.Templates.fsproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageType>Template</PackageType>
+    <PackageVersion>0.5.0</PackageVersion>
+    <PackageId>JaggerJo.Avalonia.FuncUI.Templates</PackageId>
+    <Title>Avalonia.FuncUI Templates</Title>
+    <Authors>Josua Jäger, Kevin Schneider, Angel Daniel Munoz Gonzalez</Authors>
+    <Description>Templates for Avalonia.FuncUI</Description>
+    <PackageTags>dotnet-new;templates;avalonia;funcui;mvu</PackageTags>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <ContentTargetFolders>content</ContentTargetFolders>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackOnBuild>true</PackOnBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="content\**\*" Exclude="content\**\bin\**;content\**\obj\**" />
+    <Compile Remove="**\*" />
+  </ItemGroup>
+</Project>

--- a/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/.template.config/template.json
+++ b/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/.template.config/template.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "JaggerJo",
+  "classifications": [
+    "Console",
+    "Avalonia",
+    "UI",
+    "Elmish"
+  ],
+  "name": "Avalonia FuncUI App",
+  "tags": {
+    "language": "F#",
+    "type": "project"
+  },
+  "identity": "Avalonia.FuncUI.BasicMvuTemplate",
+  "shortName": "funcui.basic.mvu",
+  "sourceName": "BasicMvuTemplate",
+  "preferNameDirectory": true
+}

--- a/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/BasicMvuTemplate.fsproj
+++ b/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/BasicMvuTemplate.fsproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Counter.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup />
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.12" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.0" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.0" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Remove=".template.config\**" />
+  </ItemGroup>
+
+</Project>

--- a/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/Counter.fs
+++ b/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/Counter.fs
@@ -1,0 +1,46 @@
+﻿
+namespace BasicMvuTemplate
+
+module Counter =
+    open Avalonia.Controls
+    open Avalonia.FuncUI.DSL
+    open Avalonia.Layout
+    
+    type State = { count : int }
+    let init = { count = 0 }
+
+    type Msg = Increment | Decrement | Reset
+
+    let update (msg: Msg) (state: State) : State =
+        match msg with
+        | Increment -> { state with count = state.count + 1 }
+        | Decrement -> { state with count = state.count - 1 }
+        | Reset -> init
+    
+    let view (state: State) (dispatch) =
+        DockPanel.create [
+            DockPanel.children [
+                Button.create [
+                    Button.dock Dock.Bottom
+                    Button.onClick (fun _ -> dispatch Reset)
+                    Button.content "reset"
+                ]                
+                Button.create [
+                    Button.dock Dock.Bottom
+                    Button.onClick (fun _ -> dispatch Decrement)
+                    Button.content "-"
+                ]
+                Button.create [
+                    Button.dock Dock.Bottom
+                    Button.onClick (fun _ -> dispatch Increment)
+                    Button.content "+"
+                ]
+                TextBlock.create [
+                    TextBlock.dock Dock.Top
+                    TextBlock.fontSize 48.0
+                    TextBlock.verticalAlignment VerticalAlignment.Center
+                    TextBlock.horizontalAlignment HorizontalAlignment.Center
+                    TextBlock.text (string state.count)
+                ]
+            ]
+        ]

--- a/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/Program.fs
+++ b/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/Program.fs
@@ -13,7 +13,7 @@ open Avalonia.FuncUI.Hosts
 type MainWindow() as this =
     inherit HostWindow()
     do
-        base.Title <- "BasicTemplate"
+        base.Title <- "BasicMvuTemplate"
         base.Width <- 400.0
         base.Height <- 400.0
         

--- a/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/Program.fs
+++ b/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/Program.fs
@@ -1,0 +1,54 @@
+﻿namespace BasicMvuTemplate
+
+open Elmish
+open Avalonia
+open Avalonia.Controls.ApplicationLifetimes
+open Avalonia.Diagnostics
+open Avalonia.Input
+open Avalonia.FuncUI
+open Avalonia.FuncUI.Elmish
+open Avalonia.Themes.Fluent
+open Avalonia.FuncUI.Hosts
+
+type MainWindow() as this =
+    inherit HostWindow()
+    do
+        base.Title <- "BasicTemplate"
+        base.Width <- 400.0
+        base.Height <- 400.0
+        
+        //this.VisualRoot.VisualRoot.Renderer.DrawFps <- true
+        //this.VisualRoot.VisualRoot.Renderer.DrawDirtyRects <- true
+#if DEBUG
+        this.AttachDevTools(KeyGesture(Key.F12))
+#endif
+
+        Elmish.Program.mkSimple (fun () -> Counter.init) Counter.update Counter.view
+        |> Program.withHost this
+#if DEBUG
+        |> Program.withConsoleTrace
+#endif
+        |> Program.run
+
+        
+type App() =
+    inherit Application()
+
+    override this.Initialize() =
+        this.Styles.Add (FluentTheme(baseUri = null, Mode = FluentThemeMode.Dark))
+
+    override this.OnFrameworkInitializationCompleted() =
+        match this.ApplicationLifetime with
+        | :? IClassicDesktopStyleApplicationLifetime as desktopLifetime ->
+            desktopLifetime.MainWindow <- MainWindow()
+        | _ -> ()
+
+module Program =
+
+    [<EntryPoint>]
+    let main(args: string[]) =
+        AppBuilder
+            .Configure<App>()
+            .UsePlatformDetect()
+            .UseSkia()
+            .StartWithClassicDesktopLifetime(args)

--- a/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/README.md
+++ b/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/README.md
@@ -1,0 +1,50 @@
+[fantomas]: https://github.com/fsprojects/fantomas
+[f# formatting]: https://marketplace.visualstudio.com/items?itemName=asti.fantomas-vs
+
+# BasicMvuTemplate
+
+This is an Avalonia.FuncUI Starter template, this template shows you in a brief way how you can create components and functions to render your UI.
+
+To run this application just type
+
+```
+dotnet run
+```
+
+You should briefly see your application window showing on your desktop.
+
+### Next Steps
+
+If you're using VSCode we recommend you to install [Fantomas]
+
+```
+dotnet new tool-manifest
+dotnet tool install fantomas
+```
+
+and add the following `.editorconfig`
+
+```editorconfig
+root = true
+
+[*]
+indent_style=space
+indent_size=4
+charset=utf-8
+trim_trailing_whitespace=true
+insert_final_newline=false
+
+[*.fs]
+fsharp_single_argument_web_mode=true
+```
+
+This should will allow Fantomas to format your code on save.
+
+Other editors like Rider and Visual Studio [F# Formatting] can also pick up these settings even if you don't install fantomas.
+
+### Feeling a little lost?
+
+Check out the documentation:
+https://avaloniacommunity.github.io/Avalonia.FuncUI.Docs/
+
+The documentation is still work in progress and will change over the next few months, but feel free to contribute and ask questions if needed.

--- a/src/Avalonia.FuncUI.Templates/content/BasicTemplate/.template.config/template.json
+++ b/src/Avalonia.FuncUI.Templates/content/BasicTemplate/.template.config/template.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "JaggerJo",
+  "classifications": [
+    "Console",
+    "Avalonia",
+    "UI",
+    "Elmish"
+  ],
+  "name": "Avalonia FuncUI App",
+  "tags": {
+    "language": "F#",
+    "type": "project"
+  },
+  "identity": "Avalonia.FuncUI.BasicTemplate",
+  "shortName": "funcui.basic",
+  "sourceName": "BasicTemplate",
+  "preferNameDirectory": true
+}

--- a/src/Avalonia.FuncUI.Templates/content/BasicTemplate/BasicTemplate.fsproj
+++ b/src/Avalonia.FuncUI.Templates/content/BasicTemplate/BasicTemplate.fsproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Counter.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.12" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.0" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.0" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.0" />
+  </ItemGroup>
+</Project>

--- a/src/Avalonia.FuncUI.Templates/content/BasicTemplate/Counter.fs
+++ b/src/Avalonia.FuncUI.Templates/content/BasicTemplate/Counter.fs
@@ -1,0 +1,48 @@
+﻿namespace BasicTemplate
+
+module Counter =
+    open Avalonia.Controls
+    open Avalonia.FuncUI
+    open Avalonia.FuncUI.DSL
+    open Avalonia.Layout
+
+    let view =
+        Component(fun ctx ->
+            let state = ctx.useState 0
+            DockPanel.create [
+                DockPanel.verticalAlignment VerticalAlignment.Center
+                DockPanel.horizontalAlignment HorizontalAlignment.Center
+                DockPanel.children [
+                    Button.create [
+                        Button.width 45
+                        Button.horizontalAlignment HorizontalAlignment.Center
+                        Button.horizontalContentAlignment HorizontalAlignment.Center
+                        Button.content "reset"
+                        Button.onClick (fun _ -> state.Set 0)
+                        Button.dock Dock.Bottom
+                    ]
+                    Button.create [
+                        Button.width 45
+                        Button.horizontalAlignment HorizontalAlignment.Center
+                        Button.horizontalContentAlignment HorizontalAlignment.Center
+                        Button.content "-"
+                        Button.onClick (fun _ -> state.Current - 1 |> state.Set)
+                        Button.dock Dock.Bottom
+                    ]
+                    Button.create [
+                        Button.width 45
+                        Button.horizontalAlignment HorizontalAlignment.Center
+                        Button.horizontalContentAlignment HorizontalAlignment.Center
+                        Button.content "+"
+                        Button.onClick (fun _ -> state.Current + 1 |> state.Set)
+                        Button.dock Dock.Bottom
+                    ]
+                    TextBlock.create [
+                        TextBlock.dock Dock.Top
+                        TextBlock.fontSize 48.0
+                        TextBlock.horizontalAlignment HorizontalAlignment.Center
+                        TextBlock.text (string state.Current)
+                    ]
+                ]
+            ]
+        )

--- a/src/Avalonia.FuncUI.Templates/content/BasicTemplate/Counter.fs
+++ b/src/Avalonia.FuncUI.Templates/content/BasicTemplate/Counter.fs
@@ -14,15 +14,15 @@ module Counter =
                 DockPanel.horizontalAlignment HorizontalAlignment.Center
                 DockPanel.children [
                     Button.create [
-                        Button.width 45
+                        Button.width 64
                         Button.horizontalAlignment HorizontalAlignment.Center
                         Button.horizontalContentAlignment HorizontalAlignment.Center
-                        Button.content "reset"
+                        Button.content "Reset"
                         Button.onClick (fun _ -> state.Set 0)
                         Button.dock Dock.Bottom
                     ]
                     Button.create [
-                        Button.width 45
+                        Button.width 64
                         Button.horizontalAlignment HorizontalAlignment.Center
                         Button.horizontalContentAlignment HorizontalAlignment.Center
                         Button.content "-"
@@ -30,7 +30,7 @@ module Counter =
                         Button.dock Dock.Bottom
                     ]
                     Button.create [
-                        Button.width 45
+                        Button.width 64
                         Button.horizontalAlignment HorizontalAlignment.Center
                         Button.horizontalContentAlignment HorizontalAlignment.Center
                         Button.content "+"

--- a/src/Avalonia.FuncUI.Templates/content/BasicTemplate/Program.fs
+++ b/src/Avalonia.FuncUI.Templates/content/BasicTemplate/Program.fs
@@ -1,0 +1,48 @@
+﻿namespace BasicTemplate
+
+open Elmish
+open Avalonia
+open Avalonia.Controls.ApplicationLifetimes
+open Avalonia.Diagnostics
+open Avalonia.Input
+open Avalonia.FuncUI
+open Avalonia.FuncUI.Elmish
+open Avalonia.Themes.Fluent
+open Avalonia.FuncUI.Hosts
+
+type MainWindow() as this =
+    inherit HostWindow()
+    do
+        base.Title <- "BasicTemplate"
+        base.Width <- 400.0
+        base.Height <- 400.0
+        this.Content <- Counter.view
+
+        //this.VisualRoot.VisualRoot.Renderer.DrawFps <- true
+        //this.VisualRoot.VisualRoot.Renderer.DrawDirtyRects <- true
+#if DEBUG
+        this.AttachDevTools(KeyGesture(Key.F12))
+#endif
+
+        
+type App() =
+    inherit Application()
+
+    override this.Initialize() =
+        this.Styles.Add (FluentTheme(baseUri = null, Mode = FluentThemeMode.Dark))
+
+    override this.OnFrameworkInitializationCompleted() =
+        match this.ApplicationLifetime with
+        | :? IClassicDesktopStyleApplicationLifetime as desktopLifetime ->
+            desktopLifetime.MainWindow <- MainWindow()
+        | _ -> ()
+
+module Program =
+
+    [<EntryPoint>]
+    let main(args: string[]) =
+        AppBuilder
+            .Configure<App>()
+            .UsePlatformDetect()
+            .UseSkia()
+            .StartWithClassicDesktopLifetime(args)

--- a/src/Avalonia.FuncUI.Templates/content/BasicTemplate/Program.fs
+++ b/src/Avalonia.FuncUI.Templates/content/BasicTemplate/Program.fs
@@ -1,12 +1,8 @@
 ﻿namespace BasicTemplate
 
-open Elmish
 open Avalonia
 open Avalonia.Controls.ApplicationLifetimes
-open Avalonia.Diagnostics
 open Avalonia.Input
-open Avalonia.FuncUI
-open Avalonia.FuncUI.Elmish
 open Avalonia.Themes.Fluent
 open Avalonia.FuncUI.Hosts
 

--- a/src/Avalonia.FuncUI.Templates/content/BasicTemplate/README.md
+++ b/src/Avalonia.FuncUI.Templates/content/BasicTemplate/README.md
@@ -1,0 +1,50 @@
+[fantomas]: https://github.com/fsprojects/fantomas
+[f# formatting]: https://marketplace.visualstudio.com/items?itemName=asti.fantomas-vs
+
+# BasicTemplate
+
+This is an Avalonia.FuncUI Starter template, this template shows you in a brief way how you can create components and functions to render your UI.
+
+To run this application just type
+
+```
+dotnet run
+```
+
+You should briefly see your application window showing on your desktop.
+
+### Next Steps
+
+If you're using VSCode we recommend you to install [Fantomas]
+
+```
+dotnet new tool-manifest
+dotnet tool install fantomas
+```
+
+and add the following `.editorconfig`
+
+```editorconfig
+root = true
+
+[*]
+indent_style=space
+indent_size=4
+charset=utf-8
+trim_trailing_whitespace=true
+insert_final_newline=false
+
+[*.fs]
+fsharp_single_argument_web_mode=true
+```
+
+This should will allow Fantomas to format your code on save.
+
+Other editors like Rider and Visual Studio [F# Formatting] can also pick up these settings even if you don't install fantomas.
+
+### Feeling a little lost?
+
+Check out the documentation:
+https://avaloniacommunity.github.io/Avalonia.FuncUI.Docs/
+
+The documentation is still work in progress and will change over the next few months, but feel free to contribute and ask questions if needed.

--- a/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/.template.config/template.json
+++ b/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/.template.config/template.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "JaggerJo",
+  "classifications": [
+    "Console",
+    "Avalonia",
+    "UI",
+    "Elmish"
+  ],
+  "name": "Avalonia FuncUI App (with extras)",
+  "tags": {
+    "language": "F#",
+    "type": "project"
+  },
+  "identity": "Avalonia.FuncUI.FullMvuTemplate",
+  "shortName": "funcUI.full.mvu",
+  "sourceName": "FullMvuTemplate",
+  "preferNameDirectory": true
+}

--- a/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/About.fs
+++ b/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/About.fs
@@ -1,6 +1,9 @@
-namespace FullTemplate
+namespace FullMvuTemplate
 
+/// You can use modules in Avalonia.FuncUI in the same way you would do
+/// in [Elmish ](https://elmish.github.io/elmish/)
 module About =
+    open Elmish
     open Avalonia.FuncUI
     open Avalonia.FuncUI.Types
     open System.Diagnostics
@@ -9,27 +12,39 @@ module About =
     open Avalonia.Layout
     open Avalonia.FuncUI.DSL
 
+
+    type State =
+        { noop: bool }
+
     type Links =
         | AvaloniaRepository
         | AvaloniaAwesome
         | FuncUIRepository
         | FuncUISamples
 
-    let openUrl url =
-        let url = 
-            match url with 
-            | AvaloniaRepository -> "https://github.com/AvaloniaUI/Avalonia"
-            | AvaloniaAwesome -> "https://github.com/AvaloniaCommunity/awesome-avalonia"
-            | FuncUIRepository -> "https://github.com/fsprojects/Avalonia.FuncUI"
-            | FuncUISamples -> "https://github.com/fsprojects/Avalonia.FuncUI/tree/master/src/Examples"
-                
-        if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
-            let start = sprintf "/c start %s" url
-            Process.Start(ProcessStartInfo("cmd", start)) |> ignore
-        else if RuntimeInformation.IsOSPlatform(OSPlatform.Linux) then
-            Process.Start("xdg-open", url) |> ignore
-        else if RuntimeInformation.IsOSPlatform(OSPlatform.OSX) then
-            Process.Start("open", url) |> ignore
+    type Msg = OpenUrl of Links
+
+    let init = { noop = false }, Cmd.none
+
+
+    let update (msg: Msg) (state: State) =
+        match msg with
+        | OpenUrl link -> 
+            let url = 
+                match link with 
+                | AvaloniaRepository -> "https://github.com/AvaloniaUI/Avalonia"
+                | AvaloniaAwesome -> "https://github.com/AvaloniaCommunity/awesome-avalonia"
+                | FuncUIRepository -> "https://github.com/fsprojects/Avalonia.FuncUI"
+                | FuncUISamples -> "https://github.com/fsprojects/Avalonia.FuncUI/tree/master/src/Examples"
+                 
+            if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
+                let start = sprintf "/c start %s" url
+                Process.Start(ProcessStartInfo("cmd", start)) |> ignore
+            else if RuntimeInformation.IsOSPlatform(OSPlatform.Linux) then
+                Process.Start("xdg-open", url) |> ignore
+            else if RuntimeInformation.IsOSPlatform(OSPlatform.OSX) then
+                Process.Start("open", url) |> ignore
+            state, Cmd.none
 
     let headerView (dock: Dock): IView = 
         StackPanel.create [
@@ -49,10 +64,10 @@ module About =
                     )
                 ]
             ]
-        ]
+        ] |> Helpers.generalize
         
         
-    let avaloniaLinksView (dock: Dock) : IView = 
+    let avaloniaLinksView (dock: Dock) (dispatch: Msg -> unit) : IView = 
         StackPanel.create [
             StackPanel.dock dock
             StackPanel.horizontalAlignment HorizontalAlignment.Left
@@ -63,18 +78,18 @@ module About =
                 ]
                 TextBlock.create [
                     TextBlock.classes [ "link" ]
-                    TextBlock.onTapped(fun _ -> openUrl AvaloniaRepository)
+                    TextBlock.onTapped(fun _ -> dispatch (OpenUrl AvaloniaRepository))
                     TextBlock.text "Avalonia Repository"
                 ]
                 TextBlock.create [
                     TextBlock.classes [ "link" ]
-                    TextBlock.onTapped(fun _ -> openUrl AvaloniaAwesome)
+                    TextBlock.onTapped(fun _ -> dispatch (OpenUrl AvaloniaAwesome))
                     TextBlock.text "Awesome Avalonia"
                 ]
             ]
-        ]
+        ] |> Helpers.generalize
         
-    let avaloniaFuncUILinksView (dock: Dock) : IView = 
+    let avaloniaFuncUILinksView (dock: Dock) (dispatch: Msg -> unit) : IView = 
         StackPanel.create [
             StackPanel.dock dock
             StackPanel.horizontalAlignment HorizontalAlignment.Right
@@ -85,28 +100,25 @@ module About =
                 ]
                 TextBlock.create [
                     TextBlock.classes [ "link" ]
-                    TextBlock.onTapped(fun _ -> openUrl FuncUIRepository)
+                    TextBlock.onTapped(fun _ -> dispatch (OpenUrl FuncUIRepository))
                     TextBlock.text "Avalonia.FuncUI Repository"
                 ]
                 TextBlock.create [
                     TextBlock.classes [ "link" ]
-                    TextBlock.onTapped(fun _ -> openUrl FuncUISamples)
+                    TextBlock.onTapped(fun _ -> dispatch (OpenUrl FuncUISamples))
                     TextBlock.text "Samples"
                 ] 
             ]
-        ]
+        ] |> Helpers.generalize
         
-    let view =
-        Component.create("About", fun _ ->
-            DockPanel.create [
-                DockPanel.horizontalAlignment HorizontalAlignment.Center
-                DockPanel.verticalAlignment VerticalAlignment.Top
-                DockPanel.margin (0.0, 20.0, 0.0, 0.0)
-                DockPanel.children [
-                    headerView Dock.Top
-                    avaloniaLinksView Dock.Left
-                    avaloniaFuncUILinksView Dock.Right
-                ]
+    let view (state: State) (dispatch: Msg -> unit) =
+        DockPanel.create [
+            DockPanel.horizontalAlignment HorizontalAlignment.Center
+            DockPanel.verticalAlignment VerticalAlignment.Top
+            DockPanel.margin (0.0, 20.0, 0.0, 0.0)
+            DockPanel.children [
+                headerView Dock.Top
+                avaloniaLinksView Dock.Left dispatch
+                avaloniaFuncUILinksView Dock.Right dispatch
             ]
-        )
-        
+        ]

--- a/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/Counter.fs
+++ b/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/Counter.fs
@@ -1,0 +1,52 @@
+namespace FullMvuTemplate
+
+module Counter =
+    open Avalonia.Controls
+    open Avalonia.FuncUI.DSL
+    open Avalonia.Layout
+    
+    type State = { count : int }
+    let init = { count = 0 }
+
+    type Msg = Increment | Decrement | Reset
+
+    let update (msg: Msg) (state: State) : State =
+        match msg with
+        | Increment -> { state with count = state.count + 1 }
+        | Decrement -> { state with count = state.count - 1 }
+        | Reset -> init
+    
+    let view (state: State) (dispatch) =
+        DockPanel.create [
+            DockPanel.children [
+                StackPanel.create [
+                    StackPanel.dock Dock.Bottom
+                    StackPanel.margin 5.0
+                    StackPanel.spacing 5.0
+                    StackPanel.children [
+                        Button.create [
+                            Button.onClick (fun _ -> dispatch Increment)
+                            Button.content "+"
+                            Button.classes [ "plus" ]
+                        ]
+                        Button.create [
+                            Button.onClick (fun _ -> dispatch Decrement)
+                            Button.content "-"
+                            Button.classes [ "minus" ]
+                        ]
+                        Button.create [
+                            Button.onClick (fun _ -> dispatch Reset)
+                            Button.content "reset"
+                        ]                         
+                    ]
+                ]
+
+                TextBlock.create [
+                    TextBlock.dock Dock.Top
+                    TextBlock.fontSize 48.0
+                    TextBlock.verticalAlignment VerticalAlignment.Center
+                    TextBlock.horizontalAlignment HorizontalAlignment.Center
+                    TextBlock.text (string state.count)
+                ]
+            ]
+        ]       

--- a/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/FullMvuTemplate.fsproj
+++ b/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/FullMvuTemplate.fsproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="Counter.fs" />
+        <Compile Include="About.fs" />
+        <Compile Include="Shell.fs" />
+        <Compile Include="Program.fs" />
+        <AvaloniaResource Include="**\*.xaml" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.12" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.0" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.0" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.0" />
+    </ItemGroup>
+</Project>

--- a/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/Program.fs
+++ b/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/Program.fs
@@ -1,9 +1,10 @@
-namespace FullTemplate
+namespace FullMvuTemplate
 
 open Avalonia
 open Avalonia.Controls.ApplicationLifetimes
 open Avalonia.FuncUI
 open Avalonia.Themes.Fluent
+
 
 /// This is your application you can ose the initialize method to load styles
 /// or handle Life Cycle events of your application
@@ -12,7 +13,7 @@ type App() =
 
     override this.Initialize() =
         this.Styles.Add (FluentTheme(baseUri = null, Mode = FluentThemeMode.Dark))
-        this.Styles.Load "avares://FullTemplate/Styles.xaml"
+        this.Styles.Load "avares://FullMvuTemplate/Styles.xaml"
 
     override this.OnFrameworkInitializationCompleted() =
         match this.ApplicationLifetime with

--- a/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/README.md
+++ b/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/README.md
@@ -1,0 +1,50 @@
+[fantomas]: https://github.com/fsprojects/fantomas
+[f# formatting]: https://marketplace.visualstudio.com/items?itemName=asti.fantomas-vs
+
+# FullMvuTemplate
+
+This is an Avalonia.FuncUI Starter template, this template shows you in a brief way how you can create components and functions to render your UI.
+
+To run this application just type
+
+```
+dotnet run
+```
+
+You should briefly see your application window showing on your desktop.
+
+### Next Steps
+
+If you're using VSCode we recommend you to install [Fantomas]
+
+```
+dotnet new tool-manifest
+dotnet tool install fantomas
+```
+
+and add the following `.editorconfig`
+
+```editorconfig
+root = true
+
+[*]
+indent_style=space
+indent_size=4
+charset=utf-8
+trim_trailing_whitespace=true
+insert_final_newline=false
+
+[*.fs]
+fsharp_single_argument_web_mode=true
+```
+
+This should will allow Fantomas to format your code on save.
+
+Other editors like Rider and Visual Studio [F# Formatting] can also pick up these settings even if you don't install fantomas.
+
+### Feeling a little lost?
+
+Check out the documentation:
+https://avaloniacommunity.github.io/Avalonia.FuncUI.Docs/
+
+The documentation is still work in progress and will change over the next few months, but feel free to contribute and ask questions if needed.

--- a/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/Shell.fs
+++ b/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/Shell.fs
@@ -1,0 +1,91 @@
+namespace FullMvuTemplate
+
+/// This is the main module of your application
+/// here you handle all of your child pages as well as their
+/// messages and their updates, useful to update multiple parts
+/// of your application, Please refer to the `view` function
+/// to see how to handle different kinds of "*child*" controls
+module Shell =
+    open Elmish
+    open Avalonia
+    open Avalonia.Controls
+    open Avalonia.Input
+    open Avalonia.FuncUI.DSL
+    open Avalonia.FuncUI
+    open Avalonia.FuncUI.Builder
+    open Avalonia.FuncUI.Hosts
+    open Avalonia.FuncUI.Elmish
+
+    type State =
+        /// store the child state in your main state
+        { aboutState: About.State; counterState: Counter.State;}
+
+    type Msg =
+        | AboutMsg of About.Msg
+        | CounterMsg of Counter.Msg
+
+    let init =
+        let aboutState, aboutCmd = About.init
+        let counterState = Counter.init
+        { aboutState = aboutState; counterState = counterState },
+        /// If your children controls don't emit any commands
+        /// in the init function, you can just return Cmd.none
+        /// otherwise, you can use a batch operation on all of them
+        /// you can add more init commands as you need
+        Cmd.batch [ aboutCmd ]
+
+    let update (msg: Msg) (state: State): State * Cmd<_> =
+        match msg with
+        | AboutMsg bpmsg ->
+            let aboutState, cmd =
+                About.update bpmsg state.aboutState
+            { state with aboutState = aboutState },
+            /// map the message to the kind of message 
+            /// your child control needs to handle
+            Cmd.map AboutMsg cmd
+        | CounterMsg countermsg ->
+            let counterMsg =
+                Counter.update countermsg state.counterState
+            { state with counterState = counterMsg },
+            /// map the message to the kind of message 
+            /// your child control needs to handle
+            Cmd.none
+
+    let view (state: State) (dispatch) =
+        DockPanel.create
+            [ DockPanel.children
+                [ TabControl.create
+                    [ TabControl.tabStripPlacement Dock.Top
+                      TabControl.viewItems
+                          [ TabItem.create
+                                [ TabItem.header "Counter Sample"
+                                  TabItem.content (Counter.view state.counterState (CounterMsg >> dispatch)) ]
+                            TabItem.create
+                                [ TabItem.header "About"
+                                  TabItem.content (About.view state.aboutState (AboutMsg >> dispatch)) ] ] ] ] ]
+
+    /// This is the main window of your application
+    /// you can do all sort of useful things here like setting heights and widths
+    /// as well as attaching your dev tools that can be super useful when developing with
+    /// Avalonia
+    type MainWindow() as this =
+        inherit HostWindow()
+        do
+            base.Title <- "Full App"
+            base.Width <- 800.0
+            base.Height <- 600.0
+            base.MinWidth <- 800.0
+            base.MinHeight <- 600.0
+
+            //this.VisualRoot.VisualRoot.Renderer.DrawFps <- true
+            //this.VisualRoot.VisualRoot.Renderer.DrawDirtyRects <- true
+#if DEBUG
+            this.AttachDevTools(KeyGesture(Key.F12))
+#endif
+
+            Elmish.Program.mkProgram (fun () -> init) update view
+            |> Program.withHost this
+#if DEBUG
+            |> Program.withConsoleTrace
+#endif
+            |> Program.run

--- a/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/Styles.xaml
+++ b/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/Styles.xaml
@@ -1,0 +1,52 @@
+<Styles
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Style Selector="Button /template/ ContentPresenter">
+        <Setter Property="CornerRadius" Value="5" />
+    </Style>
+    
+    <Style Selector="Button.plus /template/ ContentPresenter">
+        <Setter Property="Background" Value="#27ae60"/>
+        <Setter Property="BorderBrush" Value="#2ecc71"/>
+    </Style>
+    
+    <Style Selector="Button.plus:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="#23844c"/>
+    </Style>
+    
+    <Style Selector="Button.plus:pressed /template/ ContentPresenter">
+        <Setter Property="Background" Value="#1c663b"/>
+    </Style>
+    
+    <Style Selector="Button.minus /template/ ContentPresenter">
+        <Setter Property="Background" Value="#c0392b"/>
+        <Setter Property="BorderBrush" Value="#e74c3c"/>
+    </Style>
+    
+    <Style Selector="Button.minus:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="#a33225"/>
+    </Style>
+    
+    <Style Selector="Button.minus:pressed /template/ ContentPresenter">
+        <Setter Property="Background" Value="#822a20"/>
+    </Style>
+    <Style Selector="TextBlock.title">
+        <Setter Property="FontSize" Value="24" />
+        <Setter Property="FontWeight" Value="Thin" />
+        <Setter Property="Margin" Value="0 10" />
+    </Style>
+    <Style Selector="TextBlock.subtitle">
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="Thin" />
+    </Style>
+    <Style Selector="TextBlock.link">
+        <Setter Property="Foreground" Value="#009bde" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="FontStyle" Value="Oblique" />
+    </Style>
+    <Style Selector="TextBlock.link:pointerover">
+        <Setter Property="Foreground" Value="White" />
+    </Style>
+</Styles>

--- a/src/Avalonia.FuncUI.Templates/content/FullTemplate/.template.config/template.json
+++ b/src/Avalonia.FuncUI.Templates/content/FullTemplate/.template.config/template.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "JaggerJo",
+  "classifications": [
+    "Console",
+    "Avalonia",
+    "UI",
+    "Elmish"
+  ],
+  "name": "Avalonia FuncUI App (with extras)",
+  "tags": {
+    "language": "F#",
+    "type": "project"
+  },
+  "identity": "Avalonia.FuncUI.FullTemplate",
+  "shortName": "funcUI.full",
+  "sourceName": "FullTemplate",
+  "preferNameDirectory": true
+}

--- a/src/Avalonia.FuncUI.Templates/content/FullTemplate/About.fs
+++ b/src/Avalonia.FuncUI.Templates/content/FullTemplate/About.fs
@@ -1,0 +1,124 @@
+namespace FullTemplate
+
+/// You can use modules in Avalonia.FuncUI in the same way you would do
+/// in [Elmish ](https://elmish.github.io/elmish/)
+module About =
+    open Elmish
+    open Avalonia.FuncUI
+    open Avalonia.FuncUI.Types
+    open System.Diagnostics
+    open System.Runtime.InteropServices
+    open Avalonia.Controls
+    open Avalonia.Layout
+    open Avalonia.FuncUI.DSL
+
+
+    type State =
+        { noop: bool }
+
+    type Links =
+        | AvaloniaRepository
+        | AvaloniaAwesome
+        | FuncUIRepository
+        | FuncUISamples
+
+    type Msg = OpenUrl of Links
+
+    let init = { noop = false }, Cmd.none
+
+
+    let update (msg: Msg) (state: State) =
+        match msg with
+        | OpenUrl link -> 
+            let url = 
+                match link with 
+                | AvaloniaRepository -> "https://github.com/AvaloniaUI/Avalonia"
+                | AvaloniaAwesome -> "https://github.com/AvaloniaCommunity/awesome-avalonia"
+                | FuncUIRepository -> "https://github.com/fsprojects/Avalonia.FuncUI"
+                | FuncUISamples -> "https://github.com/fsprojects/Avalonia.FuncUI/tree/master/src/Examples"
+                 
+            if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
+                let start = sprintf "/c start %s" url
+                Process.Start(ProcessStartInfo("cmd", start)) |> ignore
+            else if RuntimeInformation.IsOSPlatform(OSPlatform.Linux) then
+                Process.Start("xdg-open", url) |> ignore
+            else if RuntimeInformation.IsOSPlatform(OSPlatform.OSX) then
+                Process.Start("open", url) |> ignore
+            state, Cmd.none
+
+    let headerView (dock: Dock): IView = 
+        StackPanel.create [
+            StackPanel.dock dock
+            StackPanel.verticalAlignment VerticalAlignment.Top
+            StackPanel.children [
+                TextBlock.create [
+                    TextBlock.classes [ "title" ]
+                    TextBlock.text "Thank you for using Avalonia.FuncUI"
+                ]
+                TextBlock.create [
+                    TextBlock.classes [ "subtitle" ]
+                    TextBlock.text (
+                        "Avalonia.FuncUI is a project that provides you with an Elmish DSL for Avalonia Controls\n" + 
+                        "for you to use in an F# idiomatic way. We hope you like the project and spread the word :)\n" +
+                        "Questions ? Reach to us on Gitter, also check the links below"
+                    )
+                ]
+            ]
+        ] |> Helpers.generalize
+        
+        
+    let avaloniaLinksView (dock: Dock) (dispatch: Msg -> unit) : IView = 
+        StackPanel.create [
+            StackPanel.dock dock
+            StackPanel.horizontalAlignment HorizontalAlignment.Left
+            StackPanel.children [
+                TextBlock.create [
+                    TextBlock.classes [ "title" ]
+                    TextBlock.text "Avalonia"
+                ]
+                TextBlock.create [
+                    TextBlock.classes [ "link" ]
+                    TextBlock.onTapped(fun _ -> dispatch (OpenUrl AvaloniaRepository))
+                    TextBlock.text "Avalonia Repository"
+                ]
+                TextBlock.create [
+                    TextBlock.classes [ "link" ]
+                    TextBlock.onTapped(fun _ -> dispatch (OpenUrl AvaloniaAwesome))
+                    TextBlock.text "Awesome Avalonia"
+                ]
+            ]
+        ] |> Helpers.generalize
+        
+    let avaloniaFuncUILinksView (dock: Dock) (dispatch: Msg -> unit) : IView = 
+        StackPanel.create [
+            StackPanel.dock dock
+            StackPanel.horizontalAlignment HorizontalAlignment.Right
+            StackPanel.children [
+                TextBlock.create [
+                    TextBlock.classes [ "title" ]
+                    TextBlock.text "Avalonia.FuncUI"
+                ]
+                TextBlock.create [
+                    TextBlock.classes [ "link" ]
+                    TextBlock.onTapped(fun _ -> dispatch (OpenUrl FuncUIRepository))
+                    TextBlock.text "Avalonia.FuncUI Repository"
+                ]
+                TextBlock.create [
+                    TextBlock.classes [ "link" ]
+                    TextBlock.onTapped(fun _ -> dispatch (OpenUrl FuncUISamples))
+                    TextBlock.text "Samples"
+                ] 
+            ]
+        ] |> Helpers.generalize
+        
+    let view (state: State) (dispatch: Msg -> unit) =
+        DockPanel.create [
+            DockPanel.horizontalAlignment HorizontalAlignment.Center
+            DockPanel.verticalAlignment VerticalAlignment.Top
+            DockPanel.margin (0.0, 20.0, 0.0, 0.0)
+            DockPanel.children [
+                headerView Dock.Top
+                avaloniaLinksView Dock.Left dispatch
+                avaloniaFuncUILinksView Dock.Right dispatch
+            ]
+        ]

--- a/src/Avalonia.FuncUI.Templates/content/FullTemplate/Counter.fs
+++ b/src/Avalonia.FuncUI.Templates/content/FullTemplate/Counter.fs
@@ -1,0 +1,52 @@
+namespace FullTemplate
+
+module Counter =
+    open Avalonia.Controls
+    open Avalonia.FuncUI.DSL
+    open Avalonia.Layout
+    
+    type State = { count : int }
+    let init = { count = 0 }
+
+    type Msg = Increment | Decrement | Reset
+
+    let update (msg: Msg) (state: State) : State =
+        match msg with
+        | Increment -> { state with count = state.count + 1 }
+        | Decrement -> { state with count = state.count - 1 }
+        | Reset -> init
+    
+    let view (state: State) (dispatch) =
+        DockPanel.create [
+            DockPanel.children [
+                StackPanel.create [
+                    StackPanel.dock Dock.Bottom
+                    StackPanel.margin 5.0
+                    StackPanel.spacing 5.0
+                    StackPanel.children [
+                        Button.create [
+                            Button.onClick (fun _ -> dispatch Increment)
+                            Button.content "+"
+                            Button.classes [ "plus" ]
+                        ]
+                        Button.create [
+                            Button.onClick (fun _ -> dispatch Decrement)
+                            Button.content "-"
+                            Button.classes [ "minus" ]
+                        ]
+                        Button.create [
+                            Button.onClick (fun _ -> dispatch Reset)
+                            Button.content "reset"
+                        ]                         
+                    ]
+                ]
+
+                TextBlock.create [
+                    TextBlock.dock Dock.Top
+                    TextBlock.fontSize 48.0
+                    TextBlock.verticalAlignment VerticalAlignment.Center
+                    TextBlock.horizontalAlignment HorizontalAlignment.Center
+                    TextBlock.text (string state.count)
+                ]
+            ]
+        ]       

--- a/src/Avalonia.FuncUI.Templates/content/FullTemplate/Counter.fs
+++ b/src/Avalonia.FuncUI.Templates/content/FullTemplate/Counter.fs
@@ -1,52 +1,48 @@
 namespace FullTemplate
 
 module Counter =
+    open Avalonia.FuncUI
     open Avalonia.Controls
     open Avalonia.FuncUI.DSL
     open Avalonia.Layout
     
-    type State = { count : int }
-    let init = { count = 0 }
-
-    type Msg = Increment | Decrement | Reset
-
-    let update (msg: Msg) (state: State) : State =
-        match msg with
-        | Increment -> { state with count = state.count + 1 }
-        | Decrement -> { state with count = state.count - 1 }
-        | Reset -> init
-    
-    let view (state: State) (dispatch) =
-        DockPanel.create [
-            DockPanel.children [
-                StackPanel.create [
-                    StackPanel.dock Dock.Bottom
-                    StackPanel.margin 5.0
-                    StackPanel.spacing 5.0
-                    StackPanel.children [
-                        Button.create [
-                            Button.onClick (fun _ -> dispatch Increment)
-                            Button.content "+"
-                            Button.classes [ "plus" ]
-                        ]
-                        Button.create [
-                            Button.onClick (fun _ -> dispatch Decrement)
-                            Button.content "-"
-                            Button.classes [ "minus" ]
-                        ]
-                        Button.create [
-                            Button.onClick (fun _ -> dispatch Reset)
-                            Button.content "reset"
-                        ]                         
+    let view =
+        Component.create("Counter",fun ctx ->
+            let state = ctx.useState 0
+            DockPanel.create [
+                DockPanel.verticalAlignment VerticalAlignment.Center
+                DockPanel.horizontalAlignment HorizontalAlignment.Center
+                DockPanel.children [
+                    Button.create [
+                        Button.width 64
+                        Button.horizontalAlignment HorizontalAlignment.Center
+                        Button.horizontalContentAlignment HorizontalAlignment.Center
+                        Button.content "Reset"
+                        Button.onClick (fun _ -> state.Set 0)
+                        Button.dock Dock.Bottom
+                    ]
+                    Button.create [
+                        Button.width 64
+                        Button.horizontalAlignment HorizontalAlignment.Center
+                        Button.horizontalContentAlignment HorizontalAlignment.Center
+                        Button.content "-"
+                        Button.onClick (fun _ -> state.Current - 1 |> state.Set)
+                        Button.dock Dock.Bottom
+                    ]
+                    Button.create [
+                        Button.width 64
+                        Button.horizontalAlignment HorizontalAlignment.Center
+                        Button.horizontalContentAlignment HorizontalAlignment.Center
+                        Button.content "+"
+                        Button.onClick (fun _ -> state.Current + 1 |> state.Set)
+                        Button.dock Dock.Bottom
+                    ]
+                    TextBlock.create [
+                        TextBlock.dock Dock.Top
+                        TextBlock.fontSize 48.0
+                        TextBlock.horizontalAlignment HorizontalAlignment.Center
+                        TextBlock.text (string state.Current)
                     ]
                 ]
-
-                TextBlock.create [
-                    TextBlock.dock Dock.Top
-                    TextBlock.fontSize 48.0
-                    TextBlock.verticalAlignment VerticalAlignment.Center
-                    TextBlock.horizontalAlignment HorizontalAlignment.Center
-                    TextBlock.text (string state.count)
-                ]
             ]
-        ]       
+        )

--- a/src/Avalonia.FuncUI.Templates/content/FullTemplate/FullTemplate.fsproj
+++ b/src/Avalonia.FuncUI.Templates/content/FullTemplate/FullTemplate.fsproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="Counter.fs" />
+        <Compile Include="About.fs" />
+        <Compile Include="Shell.fs" />
+        <Compile Include="Program.fs" />
+        <AvaloniaResource Include="**\*.xaml" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.12" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.0" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.0" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.0" />
+    </ItemGroup>
+</Project>

--- a/src/Avalonia.FuncUI.Templates/content/FullTemplate/Program.fs
+++ b/src/Avalonia.FuncUI.Templates/content/FullTemplate/Program.fs
@@ -1,0 +1,30 @@
+namespace FullTemplate
+
+open Avalonia
+open Avalonia.Controls.ApplicationLifetimes
+open Avalonia.FuncUI
+
+/// This is your application you can ose the initialize method to load styles
+/// or handle Life Cycle events of your application
+type App() =
+    inherit Application()
+
+    override this.Initialize() =
+        this.Styles.Load "avares://Avalonia.Themes.Default/DefaultTheme.xaml"
+        this.Styles.Load "avares://Avalonia.Themes.Default/Accents/BaseDark.xaml"
+        this.Styles.Load "avares://FullTemplate/Styles.xaml"
+
+    override this.OnFrameworkInitializationCompleted() =
+        match this.ApplicationLifetime with
+        | :? IClassicDesktopStyleApplicationLifetime as desktopLifetime ->
+            desktopLifetime.MainWindow <- Shell.MainWindow()
+        | _ -> ()
+
+module Program =
+
+    [<EntryPoint>]
+    let main (args: string []) =
+        AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .UseSkia()
+            .StartWithClassicDesktopLifetime(args)

--- a/src/Avalonia.FuncUI.Templates/content/FullTemplate/README.md
+++ b/src/Avalonia.FuncUI.Templates/content/FullTemplate/README.md
@@ -1,0 +1,50 @@
+[fantomas]: https://github.com/fsprojects/fantomas
+[f# formatting]: https://marketplace.visualstudio.com/items?itemName=asti.fantomas-vs
+
+# FullTemplate
+
+This is an Avalonia.FuncUI Starter template, this template shows you in a brief way how you can create components and functions to render your UI.
+
+To run this application just type
+
+```
+dotnet run
+```
+
+You should briefly see your application window showing on your desktop.
+
+### Next Steps
+
+If you're using VSCode we recommend you to install [Fantomas]
+
+```
+dotnet new tool-manifest
+dotnet tool install fantomas
+```
+
+and add the following `.editorconfig`
+
+```editorconfig
+root = true
+
+[*]
+indent_style=space
+indent_size=4
+charset=utf-8
+trim_trailing_whitespace=true
+insert_final_newline=false
+
+[*.fs]
+fsharp_single_argument_web_mode=true
+```
+
+This should will allow Fantomas to format your code on save.
+
+Other editors like Rider and Visual Studio [F# Formatting] can also pick up these settings even if you don't install fantomas.
+
+### Feeling a little lost?
+
+Check out the documentation:
+https://avaloniacommunity.github.io/Avalonia.FuncUI.Docs/
+
+The documentation is still work in progress and will change over the next few months, but feel free to contribute and ask questions if needed.

--- a/src/Avalonia.FuncUI.Templates/content/FullTemplate/Shell.fs
+++ b/src/Avalonia.FuncUI.Templates/content/FullTemplate/Shell.fs
@@ -1,0 +1,91 @@
+namespace FullTemplate
+
+/// This is the main module of your application
+/// here you handle all of your child pages as well as their
+/// messages and their updates, useful to update multiple parts
+/// of your application, Please refer to the `view` function
+/// to see how to handle different kinds of "*child*" controls
+module Shell =
+    open Elmish
+    open Avalonia
+    open Avalonia.Controls
+    open Avalonia.Input
+    open Avalonia.FuncUI.DSL
+    open Avalonia.FuncUI
+    open Avalonia.FuncUI.Builder
+    open Avalonia.FuncUI.Hosts
+    open Avalonia.FuncUI.Elmish
+
+    type State =
+        /// store the child state in your main state
+        { aboutState: About.State; counterState: Counter.State;}
+
+    type Msg =
+        | AboutMsg of About.Msg
+        | CounterMsg of Counter.Msg
+
+    let init =
+        let aboutState, aboutCmd = About.init
+        let counterState = Counter.init
+        { aboutState = aboutState; counterState = counterState },
+        /// If your children controls don't emit any commands
+        /// in the init function, you can just return Cmd.none
+        /// otherwise, you can use a batch operation on all of them
+        /// you can add more init commands as you need
+        Cmd.batch [ aboutCmd ]
+
+    let update (msg: Msg) (state: State): State * Cmd<_> =
+        match msg with
+        | AboutMsg bpmsg ->
+            let aboutState, cmd =
+                About.update bpmsg state.aboutState
+            { state with aboutState = aboutState },
+            /// map the message to the kind of message 
+            /// your child control needs to handle
+            Cmd.map AboutMsg cmd
+        | CounterMsg countermsg ->
+            let counterMsg =
+                Counter.update countermsg state.counterState
+            { state with counterState = counterMsg },
+            /// map the message to the kind of message 
+            /// your child control needs to handle
+            Cmd.none
+
+    let view (state: State) (dispatch) =
+        DockPanel.create
+            [ DockPanel.children
+                [ TabControl.create
+                    [ TabControl.tabStripPlacement Dock.Top
+                      TabControl.viewItems
+                          [ TabItem.create
+                                [ TabItem.header "Counter Sample"
+                                  TabItem.content (Counter.view state.counterState (CounterMsg >> dispatch)) ]
+                            TabItem.create
+                                [ TabItem.header "About"
+                                  TabItem.content (About.view state.aboutState (AboutMsg >> dispatch)) ] ] ] ] ]
+
+    /// This is the main window of your application
+    /// you can do all sort of useful things here like setting heights and widths
+    /// as well as attaching your dev tools that can be super useful when developing with
+    /// Avalonia
+    type MainWindow() as this =
+        inherit HostWindow()
+        do
+            base.Title <- "Full App"
+            base.Width <- 800.0
+            base.Height <- 600.0
+            base.MinWidth <- 800.0
+            base.MinHeight <- 600.0
+
+            //this.VisualRoot.VisualRoot.Renderer.DrawFps <- true
+            //this.VisualRoot.VisualRoot.Renderer.DrawDirtyRects <- true
+#if DEBUG
+            this.AttachDevTools(KeyGesture(Key.F12))
+#endif
+
+            Elmish.Program.mkProgram (fun () -> init) update view
+            |> Program.withHost this
+#if DEBUG
+            |> Program.withConsoleTrace
+#endif
+            |> Program.run

--- a/src/Avalonia.FuncUI.Templates/content/FullTemplate/Shell.fs
+++ b/src/Avalonia.FuncUI.Templates/content/FullTemplate/Shell.fs
@@ -1,68 +1,34 @@
 namespace FullTemplate
 
-/// This is the main module of your application
-/// here you handle all of your child pages as well as their
-/// messages and their updates, useful to update multiple parts
-/// of your application, Please refer to the `view` function
-/// to see how to handle different kinds of "*child*" controls
 module Shell =
-    open Elmish
     open Avalonia
-    open Avalonia.Controls
     open Avalonia.Input
-    open Avalonia.FuncUI.DSL
+    open Avalonia.Controls
     open Avalonia.FuncUI
-    open Avalonia.FuncUI.Builder
+    open Avalonia.FuncUI.DSL
     open Avalonia.FuncUI.Hosts
-    open Avalonia.FuncUI.Elmish
 
-    type State =
-        /// store the child state in your main state
-        { aboutState: About.State; counterState: Counter.State;}
+    let view =
+        Component(fun _ ->
+            DockPanel.create [
 
-    type Msg =
-        | AboutMsg of About.Msg
-        | CounterMsg of Counter.Msg
-
-    let init =
-        let aboutState, aboutCmd = About.init
-        let counterState = Counter.init
-        { aboutState = aboutState; counterState = counterState },
-        /// If your children controls don't emit any commands
-        /// in the init function, you can just return Cmd.none
-        /// otherwise, you can use a batch operation on all of them
-        /// you can add more init commands as you need
-        Cmd.batch [ aboutCmd ]
-
-    let update (msg: Msg) (state: State): State * Cmd<_> =
-        match msg with
-        | AboutMsg bpmsg ->
-            let aboutState, cmd =
-                About.update bpmsg state.aboutState
-            { state with aboutState = aboutState },
-            /// map the message to the kind of message 
-            /// your child control needs to handle
-            Cmd.map AboutMsg cmd
-        | CounterMsg countermsg ->
-            let counterMsg =
-                Counter.update countermsg state.counterState
-            { state with counterState = counterMsg },
-            /// map the message to the kind of message 
-            /// your child control needs to handle
-            Cmd.none
-
-    let view (state: State) (dispatch) =
-        DockPanel.create
-            [ DockPanel.children
-                [ TabControl.create
-                    [ TabControl.tabStripPlacement Dock.Top
-                      TabControl.viewItems
-                          [ TabItem.create
-                                [ TabItem.header "Counter Sample"
-                                  TabItem.content (Counter.view state.counterState (CounterMsg >> dispatch)) ]
-                            TabItem.create
-                                [ TabItem.header "About"
-                                  TabItem.content (About.view state.aboutState (AboutMsg >> dispatch)) ] ] ] ] ]
+                DockPanel.children [
+                    TabControl.create [ 
+                        TabControl.tabStripPlacement Dock.Top
+                        TabControl.viewItems [
+                            TabItem.create [
+                                TabItem.header "Counter Sample"
+                                TabItem.content Counter.view
+                            ]
+                            TabItem.create [
+                                TabItem.header "About"
+                                TabItem.content About.view
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        )
 
     /// This is the main window of your application
     /// you can do all sort of useful things here like setting heights and widths
@@ -76,6 +42,7 @@ module Shell =
             base.Height <- 600.0
             base.MinWidth <- 800.0
             base.MinHeight <- 600.0
+            this.Content <- view
 
             //this.VisualRoot.VisualRoot.Renderer.DrawFps <- true
             //this.VisualRoot.VisualRoot.Renderer.DrawDirtyRects <- true
@@ -83,9 +50,3 @@ module Shell =
             this.AttachDevTools(KeyGesture(Key.F12))
 #endif
 
-            Elmish.Program.mkProgram (fun () -> init) update view
-            |> Program.withHost this
-#if DEBUG
-            |> Program.withConsoleTrace
-#endif
-            |> Program.run

--- a/src/Avalonia.FuncUI.Templates/content/FullTemplate/Styles.xaml
+++ b/src/Avalonia.FuncUI.Templates/content/FullTemplate/Styles.xaml
@@ -1,0 +1,52 @@
+<Styles
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Style Selector="Button /template/ ContentPresenter">
+        <Setter Property="CornerRadius" Value="5" />
+    </Style>
+    
+    <Style Selector="Button.plus /template/ ContentPresenter">
+        <Setter Property="Background" Value="#27ae60"/>
+        <Setter Property="BorderBrush" Value="#2ecc71"/>
+    </Style>
+    
+    <Style Selector="Button.plus:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="#23844c"/>
+    </Style>
+    
+    <Style Selector="Button.plus:pressed /template/ ContentPresenter">
+        <Setter Property="Background" Value="#1c663b"/>
+    </Style>
+    
+    <Style Selector="Button.minus /template/ ContentPresenter">
+        <Setter Property="Background" Value="#c0392b"/>
+        <Setter Property="BorderBrush" Value="#e74c3c"/>
+    </Style>
+    
+    <Style Selector="Button.minus:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="#a33225"/>
+    </Style>
+    
+    <Style Selector="Button.minus:pressed /template/ ContentPresenter">
+        <Setter Property="Background" Value="#822a20"/>
+    </Style>
+    <Style Selector="TextBlock.title">
+        <Setter Property="FontSize" Value="24" />
+        <Setter Property="FontWeight" Value="Thin" />
+        <Setter Property="Margin" Value="0 10" />
+    </Style>
+    <Style Selector="TextBlock.subtitle">
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="Thin" />
+    </Style>
+    <Style Selector="TextBlock.link">
+        <Setter Property="Foreground" Value="#009bde" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="FontStyle" Value="Oblique" />
+    </Style>
+    <Style Selector="TextBlock.link:pointerover">
+        <Setter Property="Foreground" Value="White" />
+    </Style>
+</Styles>

--- a/src/Avalonia.FuncUI.sln
+++ b/src/Avalonia.FuncUI.sln
@@ -45,9 +45,11 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Examples.DrawingApp", "Exam
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Examples.ChordParser", "Examples\Component Examples\Examples.ChordParser\Examples.ChordParser.fsproj", "{BF5DC7CC-7ABF-40AB-97DD-6774C17FE005}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Examples.WebAssemblyPlayground", "Examples\Component Examples\Examples.WebAssemblyPlayground\Examples.WebAssemblyPlayground.fsproj", "{57D0AF41-5482-47FC-B75A-51FADD2FFEBD}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Examples.WebAssemblyPlayground", "Examples\Component Examples\Examples.WebAssemblyPlayground\Examples.WebAssemblyPlayground.fsproj", "{57D0AF41-5482-47FC-B75A-51FADD2FFEBD}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Examples.CounterApp", "Examples\Component Examples\Examples.CounterApp\Examples.CounterApp.fsproj", "{5CC37986-D6E0-438B-B895-BC82DFD22307}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Examples.CounterApp", "Examples\Component Examples\Examples.CounterApp\Examples.CounterApp.fsproj", "{5CC37986-D6E0-438B-B895-BC82DFD22307}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Avalonia.FuncUI.Templates", "Avalonia.FuncUI.Templates\Avalonia.FuncUI.Templates.fsproj", "{A0158F2D-0EA1-4D4B-9958-D3A364FC1C36}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -127,6 +129,10 @@ Global
 		{5CC37986-D6E0-438B-B895-BC82DFD22307}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5CC37986-D6E0-438B-B895-BC82DFD22307}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5CC37986-D6E0-438B-B895-BC82DFD22307}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A0158F2D-0EA1-4D4B-9958-D3A364FC1C36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A0158F2D-0EA1-4D4B-9958-D3A364FC1C36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A0158F2D-0EA1-4D4B-9958-D3A364FC1C36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A0158F2D-0EA1-4D4B-9958-D3A364FC1C36}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Hello everyone, I'm in order to ease releases and reduce the scattered maintenance, I tried to bring the  FuncUI templates into this repo.

This repo includes the following templates
- Counter MVU - `dotnet new funcui.basic.mvu`
- Counter Component - `dotnet new funcui.basic`
- Full Template MVU - `dotnet new funcui.full`


There are a few things I want to add and others to duscuss

### Add
- Full Template Component Version

### Discuss
- Removing Quickstart Template
- Make Component Templates the Default
- Adding a "Tutorial" Template 

For simple purposes I just want to add the Full Template with component version and switch it from draft to free to review that might be tomorrow, for the discuss ones, if you want to discuss in this PR or open an issue about them it would be nice as well 