### PR TITLE
Remove package references to FSharp.Core 4.7.2

### DIFF
--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog.fsproj
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog.fsproj
@@ -39,7 +39,6 @@
 
     <ItemGroup>
       <PackageReference Include="Bogus" Version="28.4.1" />
-      <PackageReference Update="FSharp.Core" Version="4.7.2" />
     </ItemGroup>
 
 </Project>

--- a/src/Avalonia.FuncUI.UnitTests/Avalonia.FuncUI.UnitTests.fsproj
+++ b/src/Avalonia.FuncUI.UnitTests/Avalonia.FuncUI.UnitTests.fsproj
@@ -23,7 +23,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Update="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Examples/Elmish Examples/Examples.Elmish.ClockApp/Examples.Elmish.ClockApp.fsproj
+++ b/src/Examples/Elmish Examples/Examples.Elmish.ClockApp/Examples.Elmish.ClockApp.fsproj
@@ -11,14 +11,13 @@
         <Compile Include="Program.fs" />
         <AvaloniaResource Include="**\*.xaml" />
     </ItemGroup>
-    
+
     <ItemGroup>
         <ProjectReference Include="..\..\..\Avalonia.FuncUI.DSL\Avalonia.FuncUI.DSL.fsproj" />
         <ProjectReference Include="..\..\..\Avalonia.FuncUI.Elmish\Avalonia.FuncUI.Elmish.fsproj" />
         <ProjectReference Include="..\..\..\Avalonia.FuncUI\Avalonia.FuncUI.fsproj" />
     </ItemGroup>
-    
+
     <ItemGroup>
-      <PackageReference Update="FSharp.Core" Version="4.7.2" />
     </ItemGroup>
 </Project>

--- a/src/Examples/Elmish Examples/Examples.Elmish.CounterApp/Examples.Elmish.CounterApp.fsproj
+++ b/src/Examples/Elmish Examples/Examples.Elmish.CounterApp/Examples.Elmish.CounterApp.fsproj
@@ -18,7 +18,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="FSharp.Core" Version="4.7.2" />
     </ItemGroup>
 
 </Project>

--- a/src/Examples/Elmish Examples/Examples.Elmish.GameOfLife/Examples.Elmish.GameOfLife.fsproj
+++ b/src/Examples/Elmish Examples/Examples.Elmish.GameOfLife/Examples.Elmish.GameOfLife.fsproj
@@ -20,9 +20,5 @@
         <ProjectReference Include="..\..\..\Avalonia.FuncUI.Elmish\Avalonia.FuncUI.Elmish.fsproj" />
         <ProjectReference Include="..\..\..\Avalonia.FuncUI\Avalonia.FuncUI.fsproj" />
     </ItemGroup>
-    
-    <ItemGroup>
-      <PackageReference Update="FSharp.Core" Version="4.7.2" />
-    </ItemGroup>
 
 </Project>

--- a/src/Examples/Elmish Examples/Examples.Elmish.MusicPlayer/Examples.Elmish.MusicPlayer.fsproj
+++ b/src/Examples/Elmish Examples/Examples.Elmish.MusicPlayer/Examples.Elmish.MusicPlayer.fsproj
@@ -21,7 +21,7 @@
         <AvaloniaResource Include="**\*.xaml" />
         <AvaloniaResource Include="Assets\Icons\**" />
     </ItemGroup>
-    
+
     <ItemGroup>
         <PackageReference Include="Avalonia.Diagnostics" Version="0.10.13" />
         <PackageReference Include="VideoLAN.LibVLC.Mac" Version="3.1.3.1" />
@@ -30,6 +30,5 @@
         <ProjectReference Include="..\..\..\Avalonia.FuncUI\Avalonia.FuncUI.fsproj" />
         <PackageReference Include="LibVLCSharp" Version="3.4.2" />
         <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.8.1" />
-        <PackageReference Update="FSharp.Core" Version="4.7.2" />
     </ItemGroup>
 </Project>

--- a/src/Examples/Elmish Examples/Examples.Elmish.Presso/Examples.Elmish.Presso.fsproj
+++ b/src/Examples/Elmish Examples/Examples.Elmish.Presso/Examples.Elmish.Presso.fsproj
@@ -5,25 +5,24 @@
         <TargetFramework>net5.0</TargetFramework>
         <RootNamespace>Examples.Presso</RootNamespace>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <AvaloniaResource Include="**\*.xaml" />
         <AvaloniaResource Include="Assets\*" />
     </ItemGroup>
-    
+
     <ItemGroup>
         <Compile Include="Lib\Library.fs" />
         <Compile Include="Main.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>
-    
+
     <ItemGroup>
         <ProjectReference Include="..\..\..\Avalonia.FuncUI.DSL\Avalonia.FuncUI.DSL.fsproj" />
         <ProjectReference Include="..\..\..\Avalonia.FuncUI.Elmish\Avalonia.FuncUI.Elmish.fsproj" />
         <ProjectReference Include="..\..\..\Avalonia.FuncUI\Avalonia.FuncUI.fsproj" />
     </ItemGroup>
-    
+
     <ItemGroup>
-      <PackageReference Update="FSharp.Core" Version="4.7.2" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
This fixes the following issue:
https://github.com/fsprojects/Avalonia.FuncUI/issues/203

Problem is that some projects explicitly reference FSharp.Core 4.7.2 whereas most projects do not add explicit package reference.  The projects that don't add package reference implicitly add latest version of FSharp.Core which causes the examples to crash with a runtime linker error do to mismatch of FSharp.Core versions.

The approach taking in this PR is simply to remove explicit references to 4.7.2 as to keep all projects consistent.