### PR TITLE
Upgrade to Avalonia 0.10.15

### DIFF
--- a/src/Avalonia.FuncUI.DSL/Avalonia.FuncUI.DSL.fsproj
+++ b/src/Avalonia.FuncUI.DSL/Avalonia.FuncUI.DSL.fsproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <Version>0.5.1</Version>
+        <Version>0.5.2</Version>
         <Authors>JaggerJo</Authors>
         <Product>JaggerJo.Avalonia.FuncUI.DSL</Product>
         <PackageId>JaggerJo.Avalonia.FuncUI.DSL</PackageId>

--- a/src/Avalonia.FuncUI.DSL/Avalonia.FuncUI.DSL.fsproj
+++ b/src/Avalonia.FuncUI.DSL/Avalonia.FuncUI.DSL.fsproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <Version>0.5.2</Version>
+        <Version>0.5.3</Version>
         <Authors>JaggerJo</Authors>
         <Product>JaggerJo.Avalonia.FuncUI.DSL</Product>
         <PackageId>JaggerJo.Avalonia.FuncUI.DSL</PackageId>
@@ -11,7 +11,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIconUrl>https://github.com/FuncUI/Avalonia.FuncUI/blob/master/github/img/nuget_icon.png?raw=true</PackageIconUrl>
         <Title>Avalonia FuncUI DSL</Title>
-        <PackageVersion>0.5.2</PackageVersion>
+        <PackageVersion>0.5.3</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
+++ b/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.5.2</Version>
+    <Version>0.5.3</Version>
     <Authors>JaggerJo</Authors>
     <Product>JaggerJo.Avalonia.FuncUI.Elmish</Product>
     <PackageId>JaggerJo.Avalonia.FuncUI.Elmish</PackageId>
@@ -11,7 +11,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageIconUrl>https://github.com/FuncUI/Avalonia.FuncUI/blob/master/github/img/nuget_icon.png?raw=true</PackageIconUrl>
     <Title>Avalonia FuncUI Elmish</Title>
-    <PackageVersion>0.5.2</PackageVersion>
+    <PackageVersion>0.5.3</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
+++ b/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.5.1</Version>
+    <Version>0.5.2</Version>
     <Authors>JaggerJo</Authors>
     <Product>JaggerJo.Avalonia.FuncUI.Elmish</Product>
     <PackageId>JaggerJo.Avalonia.FuncUI.Elmish</PackageId>
@@ -11,7 +11,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageIconUrl>https://github.com/FuncUI/Avalonia.FuncUI/blob/master/github/img/nuget_icon.png?raw=true</PackageIconUrl>
     <Title>Avalonia FuncUI Elmish</Title>
-    <PackageVersion>0.5.1</PackageVersion>
+    <PackageVersion>0.5.2</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/BasicMvuTemplate.fsproj
+++ b/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/BasicMvuTemplate.fsproj
@@ -13,11 +13,11 @@
   <ItemGroup />
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.14" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.14" />
-    <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.1" />
-    <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.1" />
-    <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.15" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.2" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.2" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/BasicMvuTemplate.fsproj
+++ b/src/Avalonia.FuncUI.Templates/content/BasicMvuTemplate/BasicMvuTemplate.fsproj
@@ -15,9 +15,9 @@
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
     <PackageReference Include="Avalonia.Diagnostics" Version="0.10.15" />
-    <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.2" />
-    <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.2" />
-    <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.2" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.3" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.3" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Avalonia.FuncUI.Templates/content/BasicTemplate/BasicTemplate.fsproj
+++ b/src/Avalonia.FuncUI.Templates/content/BasicTemplate/BasicTemplate.fsproj
@@ -13,8 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
     <PackageReference Include="Avalonia.Diagnostics" Version="0.10.15" />
-    <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.2" />
-    <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.2" />
-    <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.2" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.3" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.3" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.3" />
   </ItemGroup>
 </Project>

--- a/src/Avalonia.FuncUI.Templates/content/BasicTemplate/BasicTemplate.fsproj
+++ b/src/Avalonia.FuncUI.Templates/content/BasicTemplate/BasicTemplate.fsproj
@@ -11,10 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.14" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.14" />
-    <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.1" />
-    <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.1" />
-    <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.15" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.2" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.2" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.2" />
   </ItemGroup>
 </Project>

--- a/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/FullMvuTemplate.fsproj
+++ b/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/FullMvuTemplate.fsproj
@@ -15,8 +15,8 @@
     <ItemGroup>
         <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
         <PackageReference Include="Avalonia.Diagnostics" Version="0.10.15" />
-        <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.2" />
-        <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.2" />
-        <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.2" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.3" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.3" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.3" />
     </ItemGroup>
 </Project>

--- a/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/FullMvuTemplate.fsproj
+++ b/src/Avalonia.FuncUI.Templates/content/FullMvuTemplate/FullMvuTemplate.fsproj
@@ -13,10 +13,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Desktop" Version="0.10.14" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.14" />
-        <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.1" />
-        <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.1" />
-        <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.1" />
+        <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.15" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.2" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.2" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.2" />
     </ItemGroup>
 </Project>

--- a/src/Avalonia.FuncUI.Templates/content/FullTemplate/FullTemplate.fsproj
+++ b/src/Avalonia.FuncUI.Templates/content/FullTemplate/FullTemplate.fsproj
@@ -15,8 +15,8 @@
     <ItemGroup>
         <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
         <PackageReference Include="Avalonia.Diagnostics" Version="0.10.15" />
-        <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.2" />
-        <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.2" />
-        <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.2" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.3" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.3" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.3" />
     </ItemGroup>
 </Project>

--- a/src/Avalonia.FuncUI.Templates/content/FullTemplate/FullTemplate.fsproj
+++ b/src/Avalonia.FuncUI.Templates/content/FullTemplate/FullTemplate.fsproj
@@ -13,10 +13,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Desktop" Version="0.10.14" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.14" />
-        <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.1" />
-        <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.1" />
-        <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.1" />
+        <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.15" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.5.2" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI.DSL" Version="0.5.2" />
+        <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.5.2" />
     </ItemGroup>
 </Project>

--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.5.1</Version>
+    <Version>0.5.2</Version>
     <Authors>JaggerJo</Authors>
     <Product>JaggerJo.Avalonia.FuncUI</Product>
     <PackageId>JaggerJo.Avalonia.FuncUI</PackageId>
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.14" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.14" />
+    <PackageReference Include="Avalonia" Version="0.10.15" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.5.2</Version>
+    <Version>0.5.3</Version>
     <Authors>JaggerJo</Authors>
     <Product>JaggerJo.Avalonia.FuncUI</Product>
     <PackageId>JaggerJo.Avalonia.FuncUI</PackageId>
@@ -11,7 +11,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageIconUrl>https://github.com/FuncUI/Avalonia.FuncUI/blob/master/github/img/nuget_icon.png?raw=true</PackageIconUrl>
     <Title>Avalonia FuncUI</Title>
-    <PackageVersion>0.5.2</PackageVersion>
+    <PackageVersion>0.5.3</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As released just yesterday, to keep up with upstream:
https://github.com/AvaloniaUI/Avalonia/releases/tag/0.10.15

This also bumps the version of FuncUI to 0.5.3 across all packages to publish the new version.