### PR TITLE
Ensuring unique hook identity for custom hooks (v2)

### DIFF
--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -37,6 +37,7 @@
     <Compile Include="Components\Context\Context.EffectsHook.fs" />
     <Compile Include="Components\Context\Context.StateHook.fs" />
     <Compile Include="Components\Context\Context.fs" />
+    <Compile Include="Components\Context\Context.Group.fs" />
     <Compile Include="Components\Context\Context.Hooks.fs" />
     <Compile Include="Components\Component.fs" />
     <Compile Include="Builder.fs" />

--- a/src/Avalonia.FuncUI/Components/Context/Context.Group.fs
+++ b/src/Avalonia.FuncUI/Components/Context/Context.Group.fs
@@ -1,0 +1,19 @@
+namespace Avalonia.FuncUI
+
+open System
+open Avalonia.FuncUI
+
+/// Used to automatically prefix hooks with a group identifier.
+type internal ContextGroup (contextCore: IComponentContextCore, callerLineNumber: int) =
+    interface IComponentContextCore with
+
+        member this.trackDisposable (item: IDisposable) : unit =
+            contextCore.trackDisposable item
+
+        member this.useStateHook<'value>(stateHook: StateHook) : IReadable<'value> =
+            contextCore.useStateHook
+              { stateHook with Identity = stateHook.Identity.WithPrefix $"%i{callerLineNumber}" }
+
+        member this.useEffectHook (effect: EffectHook) : unit =
+            contextCore.useEffectHook
+              { effect with Identity = effect.Identity.WithPrefix $"%i{callerLineNumber}" }

--- a/src/Avalonia.FuncUI/Components/Context/Context.HookIdentity.fs
+++ b/src/Avalonia.FuncUI/Components/Context/Context.HookIdentity.fs
@@ -3,8 +3,10 @@ namespace Avalonia.FuncUI
 
 [<RequireQualifiedAccess; Struct>]
 type HookIdentity =
+
     /// Line number of the hooks caller
     | CallerCodeLocation of line: int
+
     /// <summary>
     /// String identity of the hook (provided explicitly or is implicitly composed)
     /// </summary>
@@ -14,7 +16,14 @@ type HookIdentity =
     /// </remarks>
     | StringIdentity of identity: string
 
-    override this.ToString () =
+    member this.StringValue =
         match this with
-        | CallerCodeLocation line -> $"Line: {line}"
+        | CallerCodeLocation line -> $"L%i{line}"
         | HookIdentity.StringIdentity identity -> identity
+
+    member this.WithPrefix (prefix: string) : HookIdentity =
+        HookIdentity.StringIdentity $"%s{prefix}.{this.StringValue}"
+
+    override this.ToString () =
+        this.StringValue
+

--- a/src/Avalonia.FuncUI/Components/Context/Context.Hooks.fs
+++ b/src/Avalonia.FuncUI/Components/Context/Context.Hooks.fs
@@ -7,7 +7,7 @@ open Avalonia.FuncUI
 [<AutoOpen>]
 module IComponentContextExtensions =
 
-    type IComponentContext with
+    type IComponentContextCore with
 
         /// <summary>
         /// Attaches a value to the component context.
@@ -30,35 +30,6 @@ module IComponentContextExtensions =
             this.useStateHook<'value>(
                 StateHook.Create (
                     identity = HookIdentity.CallerCodeLocation callerLineNumber.Value,
-                    state = StateHookValue.Lazy (fun _ -> new State<'value>(initialValue) :> IAnyReadable),
-                    renderOnChange = defaultArg renderOnChange true
-                )
-            ) :?> IWritable<'value>
-
-        /// <summary>
-        /// Attaches a value to the component context.
-        /// <example>
-        /// <code>
-        /// Component (fun ctx ->
-        ///     let count = ctx.useState (42, identity = "countHook")
-        ///     ..
-        ///     // id will have the same value during the whole component lifetime. (unless changed via 'id.Set ..')
-        ///     let id = ctx.useState (Guid.NewGuid())
-        ///     ..
-        /// )
-        /// </code>
-        /// <remarks>
-        /// Intended for composing hooks where a hook identity needs to be explicitly provided.
-        /// </remarks>
-        /// </example>
-        /// </summary>
-        /// <param name="initialValue">value should not change during the component lifetime.</param>
-        /// <param name="identity">Hook identity. Needs to be unique in the components context.</param>
-        /// <param name="renderOnChange">re-render component on change (default: true).</param>
-        member this.useState<'value>(initialValue: 'value, identity: string, ?renderOnChange: bool) : IWritable<'value> =
-            this.useStateHook<'value>(
-                StateHook.Create (
-                    identity = HookIdentity.StringIdentity identity,
                     state = StateHookValue.Lazy (fun _ -> new State<'value>(initialValue) :> IAnyReadable),
                     renderOnChange = defaultArg renderOnChange true
                 )
@@ -90,34 +61,6 @@ module IComponentContextExtensions =
             ) :?> IWritable<'value>
 
         /// <summary>
-        /// Attaches a passed <c>IWritable&lt;'value&gt;</c> value to the component context.
-        /// <example>
-        /// <code>
-        /// let countView (count: IWritable&lt;int&gt;) =
-        ///     Component (fun ctx ->
-        ///         // attach passed writable value to the component context
-        ///         let count = ctx.usePassed (count, identity = "countHook")
-        ///         ..
-        ///     )
-        /// </code>
-        /// <remarks>
-        /// Intended for composing hooks where a hook identity needs to be explicitly provided.
-        /// </remarks>
-        /// </example>
-        /// </summary>
-        /// <param name="value">value should not change during the component lifetime.</param>
-        /// <param name="identity">Hook identity. Needs to be unique in the components context.</param>
-        /// <param name="renderOnChange">re-render component on change (default: true).</param>
-        member this.usePassed<'value>(value: IWritable<'value>, identity: string, ?renderOnChange: bool) : IWritable<'value> =
-            this.useStateHook<'value>(
-                StateHook.Create (
-                    identity = HookIdentity.StringIdentity identity,
-                    state = StateHookValue.Const value,
-                    renderOnChange = defaultArg renderOnChange true
-                )
-            ) :?> IWritable<'value>
-
-        /// <summary>
         /// Attaches a passed <c>IReadable&lt;'value&gt;</c> value to the component context.
         /// <example>
         /// <code>
@@ -137,34 +80,6 @@ module IComponentContextExtensions =
             this.useStateHook<'value>(
                 StateHook.Create (
                     identity = HookIdentity.CallerCodeLocation callerLineNumber.Value,
-                    state = StateHookValue.Const value,
-                    renderOnChange = defaultArg renderOnChange true
-                )
-            )
-
-        /// <summary>
-        /// Attaches a passed <c>IReadable&lt;'value&gt;</c> value to the component context.
-        /// <example>
-        /// <code>
-        /// let countView (count: IReadable&lt;int&gt;) =
-        ///     Component (fun ctx ->
-        ///         // attach passed readable value to the component context
-        ///         let count = ctx.usePassedRead(count, identity = "countHook")
-        ///         ..
-        ///     )
-        /// </code>
-        /// <remarks>
-        /// Intended for composing hooks where a hook identity needs to be explicitly provided.
-        /// </remarks>
-        /// </example>
-        /// </summary>
-        /// <param name="value">value should not change during the component lifetime.</param>
-        /// <param name="identity">Hook identity. Needs to be unique in the components context.</param>
-        /// <param name="renderOnChange">re-render component on change (default: true).</param>
-        member this.usePassedRead<'value>(value: IReadable<'value>, identity: string, ?renderOnChange: bool) : IReadable<'value> =
-            this.useStateHook<'value>(
-                StateHook.Create (
-                    identity = HookIdentity.StringIdentity identity,
                     state = StateHookValue.Const value,
                     renderOnChange = defaultArg renderOnChange true
                 )
@@ -214,44 +129,6 @@ module IComponentContextExtensions =
         ///         ctx.useEffect (
         ///             handler = (fun _ ->
         ///                 // do something
-        ///                 ..
-        ///                 // return a cleanup function
-        ///                 { new IDisposable with
-        ///                     method Dispose() =
-        ///                         // do something
-        ///                 }
-        ///             ),
-        ///             triggers = [
-        ///                 EffectTrigger.AfterChange count
-        ///                 EffectTrigger.AfterRender
-        ///                 EffectTrigger.AfterInit
-        ///             ],
-        ///             identity = "effectIdentity"
-        ///         )
-        ///         ..
-        ///     )
-        /// </code>
-        /// <remarks>
-        /// Intended for composing hooks where a hook identity needs to be explicitly provided.
-        /// </remarks>
-        /// </example>
-        /// </summary>
-        /// <param name="handler">handler is called when a trigger fires.</param>
-        /// <param name="triggers">list of effect triggers</param>
-        /// <param name="identity">Hook identity. Needs to be unique in the components context.</param>
-        member this.useEffect (handler: unit -> IDisposable, triggers: EffectTrigger list, identity: string) =
-            this.useEffectHook (EffectHook.Create(HookIdentity.StringIdentity identity, handler, triggers))
-
-        /// <summary>
-        /// Attaches a effect to the component context.
-        /// <example>
-        /// <code>
-        /// let view () =
-        ///     Component (fun ctx ->
-        ///         let count = ctx.useState 0
-        ///         ctx.useEffect (
-        ///             handler = (fun _ ->
-        ///                 // do something
         ///             ),
         ///             triggers = [
         ///                 EffectTrigger.AfterChange count
@@ -270,34 +147,100 @@ module IComponentContextExtensions =
         member this.useEffect (handler: unit -> unit, triggers: EffectTrigger list, [<CallerLineNumber>] ?callerLineNumber: int) =
             this.useEffectHook (EffectHook.Create(HookIdentity.CallerCodeLocation callerLineNumber.Value, (fun _ -> handler(); null), triggers))
 
+
+    type IComponentContextCore with
+
+
         /// <summary>
-        /// Attaches a effect to the component context.
+        ///
+        /// </summary>
         /// <example>
         /// <code>
-        /// let view () =
-        ///     Component (fun ctx ->
-        ///         let count = ctx.useState 0
-        ///         ctx.useEffect (
-        ///             handler = (fun _ ->
-        ///                 // do something
-        ///             ),
-        ///             triggers = [
-        ///                 EffectTrigger.AfterChange count
-        ///                 EffectTrigger.AfterRender
-        ///                 EffectTrigger.AfterInit
-        ///             ],
-        ///             identity = "effectIdentity"
+        ///
+        /// type IComponentContextCore with
+        ///     (* custom hook *)
+        ///     member this.randomNumberHook ([&lt;CallerLineNumber&gt;] ?callerLineNumber: int) : IStateHook&lt;int&gt; =
+        ///         this.useGrouped (callerLineNumber.Value, fun ctx ->
+        ///             let a = ctx.useState ("a", ?callerLineNumber: callerLineNumber)
+        ///             let b = ctx.useState ("b", ?callerLineNumber: callerLineNumber)
+        ///             ctx.useState (randomInt.Next(), ?callerLineNumber: callerLineNumber)
         ///         )
-        ///         ..
-        ///     )
+        ///
+        /// type Views () =
+        ///     (* example component *)
+        ///     static member ExampleView () =
+        ///         Component ("example", fun ctx ->
+        ///             let randomA = ctx.useRandomNumberHook ()
+        ///             let randomB = ctx.useRandomNumberHook ()
+        ///
+        ///             TextBlock.create [
+        ///                 // 'randomA' and 'randomB' can be different as they have different hook identities.
+        ///                 TextBlock.text $"A: {randomA.current} B: {randomB.current}"
+        ///             ]
+        ///         )
         /// </code>
-        /// <remarks>
-        /// Intended for composing hooks where a hook identity needs to be explicitly provided.
-        /// </remarks>
         /// </example>
-        /// </summary>
-        /// <param name="handler">handler is called when a trigger fires.</param>
-        /// <param name="triggers">list of effect triggers</param>
-        /// <param name="identity">Hook identity. Needs to be unique in the components context.</param>
-        member this.useEffect (handler: unit -> unit, triggers: EffectTrigger list, identity: string) =
-            this.useEffectHook (EffectHook.Create(HookIdentity.StringIdentity identity, (fun _ -> handler(); null), triggers))
+        /// <remarks>
+        /// Below an example of why grouping is needed / what problem this solves.
+        /// <code>
+        ///
+        /// type IComponentContextCore with
+        ///     (* custom hook *)
+        ///     member this.randomNumberHook () : IStateHook&lt;int&gt; =
+        ///         this.useState (randomInt.Next())
+        ///
+        /// type Views () =
+        ///     (* example component *)
+        ///     static member ExampleView () =
+        ///         Component ("example", fun ctx ->
+        ///             let randomA = ctx.useRandomNumberHook ()
+        ///             let randomB = ctx.useRandomNumberHook ()
+        ///
+        ///             TextBlock.create [
+        ///                 TextBlock.text $"A: {randomA.current} B: {randomB.current}"
+        ///             ]
+        ///         )
+        /// </code>
+        /// <para>
+        /// The problem is that 'randomA' and 'randomB' both point to the same value, because the end up getting the same
+        /// hook identity.
+        /// This is the case because the Hook identity is implicitly provided by the caller line number. So the
+        /// 'randomNumberHook' actually looks like this:
+        /// </para>
+        /// <code>
+        /// type IComponentContextCore with
+        ///     (* custom hook *)
+        ///     member this.randomNumberHook () : IStateHook&lt;int&gt; =
+        ///         this.useState (randomInt.Next(), callerLineNumber: 42)
+        /// </code>
+        /// <para>
+        /// This problem can be solved by threading through the caller line number:
+        /// </para>
+        /// <code>
+        /// type IComponentContextCore with
+        ///     (* custom hook *)
+        ///     member this.randomNumberHook ([&lt;CallerLineNumber&gt;] ?callerLineNumber: int) : IStateHook&lt;int&gt; =
+        ///         this.useState (randomInt.Next(), ?callerLineNumber: callerLineNumber)
+        /// </code>
+        /// <para>
+        /// This solves the initial problem, but what if the custom hook function needs to call multiple other hooks?
+        /// This would require custom code to give each call a unique caller line number / or more generally a hook
+        /// identity.
+        /// </para>
+        /// <code>
+        /// type IComponentContextCore with
+        ///     (* custom hook *)
+        ///     member this.randomNumberHook ([&lt;CallerLineNumber&gt;] ?callerLineNumber: int) : IStateHook&lt;int&gt; =
+        ///         let a = this.useState ("a", ?callerLineNumber: callerLineNumber)       // -|
+        ///         let b = this.useState ("b", ?callerLineNumber: callerLineNumber)       // -|- same line number
+        ///         this.useState (randomInt.Next(), ?callerLineNumber: callerLineNumber)  // -|
+        /// </code>
+        /// <para>
+        /// It would be possible to solve this by manually threading through the caller line number and providing an
+        /// offset / postfix for each call.
+        /// This would be quite verbose and error prone, but is exactly what the 'group' function does implicitly.
+        /// </para>
+        /// </remarks>
+        member this.useGrouped (callerLineNumber: int, render: IComponentContextCore -> 'state) : 'state =
+            let ctxGroup = ContextGroup(this, callerLineNumber)
+            render ctxGroup

--- a/src/Avalonia.FuncUI/Components/Context/Context.fs
+++ b/src/Avalonia.FuncUI/Components/Context/Context.fs
@@ -6,22 +6,7 @@ open Avalonia.FuncUI
 open Avalonia.FuncUI.Types
 open Avalonia.Threading
 
-type IComponentContext =
-
-    /// <summary>
-    /// Forces the component to be re-rendered.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Components actually only get re-rendered if the component content changed - and
-    /// even then only the content that is actually different from the previous render
-    /// will get patched.
-    /// </para>
-    /// <para>
-    /// To ensure a full re-render the component key needs to be changed.
-    /// </para>
-    /// </remarks>
-    abstract forceRender: unit -> unit
+type IComponentContextCore =
 
     /// <summary>
     /// <para>
@@ -45,6 +30,24 @@ type IComponentContext =
     /// (used by extension methods that add the default effect hooks)
     /// </summary>
     abstract useEffectHook: EffectHook -> unit
+
+type IComponentContext =
+    inherit IComponentContextCore
+
+    /// <summary>
+    /// Forces the component to be re-rendered.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Components actually only get re-rendered if the component content changed - and
+    /// even then only the content that is actually different from the previous render
+    /// will get patched.
+    /// </para>
+    /// <para>
+    /// To ensure a full re-render the component key needs to be changed.
+    /// </para>
+    /// </remarks>
+    abstract forceRender: unit -> unit
 
     /// <summary>
     /// <para>


### PR DESCRIPTION
More elegant than what I did in https://github.com/fsprojects/Avalonia.FuncUI/pull/207 .

Basically this allows library authors to create composed hooks without explicitly giving each hook a unique identity. 