### PR TITLE
Add onSelectedItemChanged to TreeView

### DIFF
--- a/src/Avalonia.FuncUI.DSL/TreeView.fs
+++ b/src/Avalonia.FuncUI.DSL/TreeView.fs
@@ -19,13 +19,19 @@ module TreeView =
             AttrBuilder<'t>.CreateProperty<bool>(TreeView.AutoScrollToSelectedItemProperty, value, ValueNone)
         
         /// <summary>
-        /// Sets the selected items.
+        /// Subscribes to changes in the SelectedItem property.
+        /// </summary>
+        static member onSelectedItemChanged<'t when 't :> TreeView>(func: obj -> unit, ?subPatchOptions) =
+            AttrBuilder<'t>.CreateSubscription<obj>(TreeView.SelectedItemProperty, func, ?subPatchOptions = subPatchOptions)
+
+        /// <summary>
+        /// Sets the selected item.
         /// </summary>
         static member selectedItem<'t when 't :> TreeView>(value: obj) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<obj>(TreeView.SelectedItemProperty, value, ValueNone)
          
         /// <summary>
-        /// Sets the selected item.
+        /// Sets the selected items.
         /// </summary>
         static member selectedItems<'t when 't :> TreeView>(value: IList) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<IList>(TreeView.SelectedItemsProperty, value, ValueNone)


### PR DESCRIPTION
Hi,
I was having a go at a UI using a TreeView and I needed to handle a selection changed event, and I didn't see it in the current version.
I added a local extension method and that seemed to work ok, but I thought i'd see if it could be added to the build in bindings (I'm not sure what the situation is with just adding extra bindings to existing controls?)

Thanks