### PR TITLE
Add support for RichTextBlock

### DIFF
--- a/src/Avalonia.FuncUI.UnitTests/VirtualDom/VirtualDom.PatcherTests.fs
+++ b/src/Avalonia.FuncUI.UnitTests/VirtualDom/VirtualDom.PatcherTests.fs
@@ -44,19 +44,19 @@ module PatcherTests =
 
     [<Fact>]
     let ``Patch Styles, Classes or Resources`` () =
-        let stylesGetter: IControl -> obj = (fun c -> (c :?> StyledElement).Styles :> obj)
-        let stylesSetter: IControl * obj -> unit =
+        let stylesGetter: IAvaloniaObject -> obj = (fun c -> (c :?> StyledElement).Styles :> obj)
+        let stylesSetter: IAvaloniaObject * obj -> unit =
             (fun (c, v) ->
                 let se = (c :?> StyledElement)
                 let s = v :?> Styles
                 se.Styles.Clear()
                 se.Styles.AddRange(s))
 
-        let classesGetter: IControl -> obj = (fun c -> (c :?> StyledElement).Classes :> obj)
-        let classesSetter: IControl * obj -> unit = (fun (c, v) -> (c :?> StyledElement).Classes <- v :?> Classes)
+        let classesGetter: IAvaloniaObject -> obj = (fun c -> (c :?> StyledElement).Classes :> obj)
+        let classesSetter: IAvaloniaObject * obj -> unit = (fun (c, v) -> (c :?> StyledElement).Classes <- v :?> Classes)
 
-        let resourcesGetter: IControl -> obj = (fun c -> (c :?> StyledElement).Resources :> obj)
-        let resourcesSetter: IControl * obj -> unit = (fun (c, v) -> (c :?> StyledElement).Resources <- v :?> IResourceDictionary)
+        let resourcesGetter: IAvaloniaObject -> obj = (fun c -> (c :?> StyledElement).Resources :> obj)
+        let resourcesSetter: IAvaloniaObject * obj -> unit = (fun (c, v) -> (c :?> StyledElement).Resources <- v :?> IResourceDictionary)
 
         let delta : Delta.ViewDelta =
             {

--- a/src/Avalonia.FuncUI.sln
+++ b/src/Avalonia.FuncUI.sln
@@ -55,6 +55,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Items", "_Solutio
 		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Examples.InlineText", "Examples\Component Examples\Examples.InlineText\Examples.InlineText.fsproj", "{B8D8C84B-05AD-475B-BE81-A30544CE0149}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -133,6 +135,10 @@ Global
 		{A0158F2D-0EA1-4D4B-9958-D3A364FC1C36}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A0158F2D-0EA1-4D4B-9958-D3A364FC1C36}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A0158F2D-0EA1-4D4B-9958-D3A364FC1C36}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8D8C84B-05AD-475B-BE81-A30544CE0149}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8D8C84B-05AD-475B-BE81-A30544CE0149}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8D8C84B-05AD-475B-BE81-A30544CE0149}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8D8C84B-05AD-475B-BE81-A30544CE0149}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -154,6 +160,7 @@ Global
 		{BF5DC7CC-7ABF-40AB-97DD-6774C17FE005} = {F50826CE-D9BC-45CF-A110-C42225B75AD3}
 		{57D0AF41-5482-47FC-B75A-51FADD2FFEBD} = {F50826CE-D9BC-45CF-A110-C42225B75AD3}
 		{5CC37986-D6E0-438B-B895-BC82DFD22307} = {F50826CE-D9BC-45CF-A110-C42225B75AD3}
+		{B8D8C84B-05AD-475B-BE81-A30544CE0149} = {F50826CE-D9BC-45CF-A110-C42225B75AD3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4630E817-6780-4C98-9379-EA3B45224339}

--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -127,6 +127,7 @@
     <Compile Include="DSL\TabItem.fs" />
     <Compile Include="DSL\TickBar.fs" />
     <Compile Include="DSL\Viewbox.fs" />
+    <Compile Include="DSL\RichTextBlock.fs" />
   </ItemGroup>
 
 </Project>

--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -80,6 +80,7 @@
     <Compile Include="DSL\Shapes\Path.fs" />
     <Compile Include="DSL\Calendar\Calendar.fs" />
     <Compile Include="DSL\Calendar\CalendarDatePicker.fs" />
+    <Compile Include="DSL\Documents\Run.fs" />
     <Compile Include="DSL\DatePicker.fs" />
     <Compile Include="DSL\TimePicker.fs" />
     <Compile Include="DSL\ItemsControl.fs" />

--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -82,6 +82,11 @@
     <Compile Include="DSL\Calendar\Calendar.fs" />
     <Compile Include="DSL\Calendar\CalendarDatePicker.fs" />
     <Compile Include="DSL\Documents\Run.fs" />
+    <Compile Include="DSL\Documents\Span.fs" />
+    <Compile Include="DSL\Documents\Bold.fs" />
+    <Compile Include="DSL\Documents\LineBreak.fs" />
+    <Compile Include="DSL\Documents\Italic.fs" />
+    <Compile Include="DSL\Documents\Underline.fs" />
     <Compile Include="DSL\DatePicker.fs" />
     <Compile Include="DSL\TimePicker.fs" />
     <Compile Include="DSL\ItemsControl.fs" />

--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -65,6 +65,7 @@
     <Compile Include="DSL\Primitives\Thumb.fs" />
     <Compile Include="DSL\Primitives\AccessText.fs" />
     <Compile Include="DSL\Primitives\ScrollBar.fs" />
+    <Compile Include="DSL\Primitives\TextElement.fs" />
     <Compile Include="DSL\Panels\Canvas.fs" />
     <Compile Include="DSL\Panels\DockPanel.fs" />
     <Compile Include="DSL\Panels\Grid.fs" />

--- a/src/Avalonia.FuncUI/Builder.fs
+++ b/src/Avalonia.FuncUI/Builder.fs
@@ -243,16 +243,6 @@ type AttrBuilder<'view>() =
 
         attr :> IAttr<'view>
         
-    /// <summary>
-    /// Creates an attribute with a list of inlines to be applied to a control.
-    /// </summary>
-    /// <param name="inlines">List of inlines to be applied.</param>
-    static member CreateInlineProperty(property: AvaloniaProperty, inlines: IInline list) : IAttr<'inlineType> =
-        Attr<'inlineType>.Inline {
-            HostAccessor = property
-            Inlines = inlines
-        }
-
 [<AbstractClass; Sealed>]
 type ViewBuilder() =
 
@@ -262,13 +252,3 @@ type ViewBuilder() =
           View.Attrs = attrs
           View.ConstructorArgs = null
           View.Outlet = ValueNone }
-
-[<AbstractClass; Sealed>]
-type InlineBuilder() =
-
-    static member Create<'inlineType>(attrs: IAttr<'inlineType> list) : IInline =
-        { Inline.InlineElement =
-            typeof<'inlineType>
-            |> Activator.CreateInstance
-            |> Utils.cast<Avalonia.Controls.Documents.Inline>
-          Inline.Attrs = attrs }

--- a/src/Avalonia.FuncUI/Builder.fs
+++ b/src/Avalonia.FuncUI/Builder.fs
@@ -30,15 +30,15 @@ open Avalonia.FuncUI.Types
 open Avalonia.FuncUI.Library
 
 module private Helpers =
-    let wrappedGetter<'view, 'value>(func: 'view -> 'value) : IControl -> obj =
-        let wrapper (control: IControl) : obj =
+    let wrappedGetter<'view, 'value>(func: 'view -> 'value) : IAvaloniaObject -> obj =
+        let wrapper (control: IAvaloniaObject) : obj =
             let view = control :> obj :?> 'view
             let value = func view
             value :> obj
         wrapper
 
-    let wrappedSetter<'view, 'value>(func: 'view * 'value -> unit) : IControl * obj -> unit =
-        let wrapper (control: IControl, value: obj) : unit =
+    let wrappedSetter<'view, 'value>(func: 'view * 'value -> unit) : IAvaloniaObject * obj -> unit =
+        let wrapper (control: IAvaloniaObject, value: obj) : unit =
             let view = control :> obj :?> 'view
             let value = value :?> 'value
             func(view, value)

--- a/src/Avalonia.FuncUI/Builder.fs
+++ b/src/Avalonia.FuncUI/Builder.fs
@@ -162,7 +162,7 @@ type AttrBuilder<'view>() =
     static member CreateSubscription<'arg, 'owner when 'owner :> AvaloniaObject>(property: DirectProperty<'owner, 'arg>, func: 'arg -> unit, ?subPatchOptions: SubPatchOptions) : IAttr<'view> =
         // subscribe to avalonia property
         // TODO: extract to helpers module
-        let subscribeFunc (control: IControl, _handler: 'h) =
+        let subscribeFunc (control: IAvaloniaObject, _handler: 'h) =
             let cts = new CancellationTokenSource()
             control
                 .GetObservable(property)
@@ -184,7 +184,7 @@ type AttrBuilder<'view>() =
     static member CreateSubscription<'arg>(property: AvaloniaProperty<'arg>, func: 'arg -> unit, ?subPatchOptions: SubPatchOptions) : IAttr<'view> =
         // subscribe to avalonia property
         // TODO: extract to helpers module
-        let subscribeFunc (control: IControl, _handler: 'h) =
+        let subscribeFunc (control: IAvaloniaObject, _handler: 'h) =
             let cts = new CancellationTokenSource()
             control
                 .GetObservable(property)
@@ -225,10 +225,10 @@ type AttrBuilder<'view>() =
     /// <summary>
     /// Create a Event Subscription Attribute for a .Net Event
     /// </summary>
-    static member CreateSubscription<'arg>(name: string, factory: IControl * ('arg -> unit) * CancellationToken -> unit, func: 'arg -> unit, ?subPatchOptions: SubPatchOptions) =
+    static member CreateSubscription<'arg>(name: string, factory: IAvaloniaObject * ('arg -> unit) * CancellationToken -> unit, func: 'arg -> unit, ?subPatchOptions: SubPatchOptions) =
         // TODO: extract to helpers module
         // subscribe to event
-        let subscribeFunc (control: IControl, _handler: 'h) =
+        let subscribeFunc (control: IAvaloniaObject, _handler: 'h) =
             let cts = new CancellationTokenSource()
             factory(control, func, cts.Token)
             cts

--- a/src/Avalonia.FuncUI/Builder.fs
+++ b/src/Avalonia.FuncUI/Builder.fs
@@ -242,6 +242,16 @@ type AttrBuilder<'view>() =
         }
 
         attr :> IAttr<'view>
+        
+    /// <summary>
+    /// Creates an attribute with a list of inlines to be applied to a control.
+    /// </summary>
+    /// <param name="inlines">List of inlines to be applied.</param>
+    static member CreateInlineProperty(property: AvaloniaProperty, inlines: IInline list) : IAttr<'inlineType> =
+        Attr<'inlineType>.Inline {
+            HostAccessor = property
+            Inlines = inlines
+        }
 
 [<AbstractClass; Sealed>]
 type ViewBuilder() =
@@ -252,4 +262,13 @@ type ViewBuilder() =
           View.Attrs = attrs
           View.ConstructorArgs = null
           View.Outlet = ValueNone }
-        :> IView<'view>
+
+[<AbstractClass; Sealed>]
+type InlineBuilder() =
+
+    static member Create<'inlineType>(attrs: IAttr<'inlineType> list) : IInline =
+        { Inline.InlineElement =
+            typeof<'inlineType>
+            |> Activator.CreateInstance
+            |> Utils.cast<Avalonia.Controls.Documents.Inline>
+          Inline.Attrs = attrs }

--- a/src/Avalonia.FuncUI/DSL/Documents/Bold.fs
+++ b/src/Avalonia.FuncUI/DSL/Documents/Bold.fs
@@ -1,0 +1,20 @@
+namespace Avalonia.FuncUI.DSL
+
+open Avalonia.FuncUI.Types
+
+[<AutoOpen>]
+module Bold =  
+    open Avalonia.FuncUI.Builder
+    open Avalonia.Controls.Documents
+
+    let create (attrs: IAttr<Bold> list): IView<Bold> =
+        ViewBuilder.Create(attrs)
+        
+    let simple (text: string): IView<Bold> =
+        ViewBuilder.Create([
+            Bold.inlines [
+                Run.create [
+                    Run.text text
+                ] :> IView
+            ]
+        ])

--- a/src/Avalonia.FuncUI/DSL/Documents/Italic.fs
+++ b/src/Avalonia.FuncUI/DSL/Documents/Italic.fs
@@ -1,0 +1,19 @@
+namespace Avalonia.FuncUI.DSL
+
+[<AutoOpen>]
+module Italic =  
+    open Avalonia.FuncUI.Builder
+    open Avalonia.FuncUI.Types
+    open Avalonia.Controls.Documents
+
+    let create (attrs: IAttr<Italic> list): IView<Italic> =
+        ViewBuilder.Create(attrs)
+        
+    let simple (text: string): IView<Italic> =
+        ViewBuilder.Create([
+            Italic.inlines [
+                Run.create [
+                    Run.text text
+                ] :> IView
+            ]
+        ])

--- a/src/Avalonia.FuncUI/DSL/Documents/LineBreak.fs
+++ b/src/Avalonia.FuncUI/DSL/Documents/LineBreak.fs
@@ -1,0 +1,14 @@
+namespace Avalonia.FuncUI.DSL
+
+[<AutoOpen>]
+module LineBreak =  
+    open Avalonia.FuncUI.Builder
+    open Avalonia.FuncUI.Types
+    open Avalonia.Controls.Documents
+
+    let create (attrs: IAttr<LineBreak> list): IView<LineBreak> =
+        ViewBuilder.Create(attrs)
+        
+    /// Creates a simple line-break with no attributes.
+    let simple : IView<LineBreak> =
+        create([])

--- a/src/Avalonia.FuncUI/DSL/Documents/Run.fs
+++ b/src/Avalonia.FuncUI/DSL/Documents/Run.fs
@@ -1,14 +1,13 @@
 namespace Avalonia.FuncUI.DSL
 
 [<AutoOpen>]
-module Run =  
+module Run =
     open Avalonia.FuncUI.Builder
     open Avalonia.FuncUI.Types
     open Avalonia.Controls.Documents
 
-    let create (attrs: IAttr<Run> list): IView<Run> =
-        ViewBuilder.Create(attrs)
-    
+    let create (attrs: IAttr<Run> list) : IView<Run> = ViewBuilder.Create(attrs)
+
     type Run with
         static member text<'t when 't :> Run>(value: string) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<string>(Run.TextProperty, value, ValueNone)

--- a/src/Avalonia.FuncUI/DSL/Documents/Run.fs
+++ b/src/Avalonia.FuncUI/DSL/Documents/Run.fs
@@ -7,8 +7,8 @@ module Run =
     open Avalonia.Media
     open Avalonia.Controls.Documents
 
-    let create (attrs: IAttr<Run> list): IInline =
-        InlineBuilder.Create<Run>(attrs)
+    let create (attrs: IAttr<Run> list): IView<Run> =
+        ViewBuilder.Create(attrs)
     
     type Run with
         static member text<'t when 't :> Run>(value: string) : IAttr<'t> =

--- a/src/Avalonia.FuncUI/DSL/Documents/Run.fs
+++ b/src/Avalonia.FuncUI/DSL/Documents/Run.fs
@@ -4,7 +4,6 @@ namespace Avalonia.FuncUI.DSL
 module Run =  
     open Avalonia.FuncUI.Builder
     open Avalonia.FuncUI.Types
-    open Avalonia.Media
     open Avalonia.Controls.Documents
 
     let create (attrs: IAttr<Run> list): IView<Run> =
@@ -13,6 +12,3 @@ module Run =
     type Run with
         static member text<'t when 't :> Run>(value: string) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<string>(Run.TextProperty, value, ValueNone)
-            
-        static member background<'t when 't :> Run>(value: IBrush) : IAttr<'t> =
-            AttrBuilder<'t>.CreateProperty<IBrush>(Run.BackgroundProperty, value, ValueNone)

--- a/src/Avalonia.FuncUI/DSL/Documents/Run.fs
+++ b/src/Avalonia.FuncUI/DSL/Documents/Run.fs
@@ -1,0 +1,31 @@
+namespace Avalonia.FuncUI.DSL
+
+open Avalonia.FuncUI.VirtualDom
+open Avalonia.FuncUI.VirtualDom.Delta
+open Avalonia.Media
+
+[<AutoOpen>]
+module Run =  
+    open Avalonia.Controls.Documents
+    open Avalonia.FuncUI.Builder
+    open Avalonia.FuncUI.Types
+
+    let create (attrs: IAttr<Run> list): Inline =
+        let run = Run()
+        
+        attrs
+        |> List.choose (fun attr ->
+            match attr.Property with
+            | Some prop -> PropertyDelta.From prop |> Some
+            | None -> None
+        )
+        |> List.iter (Patcher.patchProperty run)
+        
+        run
+    
+    type Run with
+        static member text<'t when 't :> Run>(value: string) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<string>(Run.TextProperty, value, ValueNone)
+            
+        static member background<'t when 't :> Run>(value: IBrush) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<IBrush>(Run.BackgroundProperty, value, ValueNone)

--- a/src/Avalonia.FuncUI/DSL/Documents/Run.fs
+++ b/src/Avalonia.FuncUI/DSL/Documents/Run.fs
@@ -1,27 +1,14 @@
 namespace Avalonia.FuncUI.DSL
 
-open Avalonia.FuncUI.VirtualDom
-open Avalonia.FuncUI.VirtualDom.Delta
-open Avalonia.Media
-
 [<AutoOpen>]
 module Run =  
-    open Avalonia.Controls.Documents
     open Avalonia.FuncUI.Builder
     open Avalonia.FuncUI.Types
+    open Avalonia.Media
+    open Avalonia.Controls.Documents
 
-    let create (attrs: IAttr<Run> list): Inline =
-        let run = Run()
-        
-        attrs
-        |> List.choose (fun attr ->
-            match attr.Property with
-            | Some prop -> PropertyDelta.From prop |> Some
-            | None -> None
-        )
-        |> List.iter (Patcher.patchProperty run)
-        
-        run
+    let create (attrs: IAttr<Run> list): IInline =
+        InlineBuilder.Create<Run>(attrs)
     
     type Run with
         static member text<'t when 't :> Run>(value: string) : IAttr<'t> =

--- a/src/Avalonia.FuncUI/DSL/Documents/Span.fs
+++ b/src/Avalonia.FuncUI/DSL/Documents/Span.fs
@@ -1,0 +1,18 @@
+namespace Avalonia.FuncUI.DSL
+
+[<AutoOpen>]
+module Span =  
+    open Avalonia.FuncUI.Builder
+    open Avalonia.FuncUI.Types
+    open Avalonia.Controls.Documents
+
+    let create (attrs: IAttr<Span> list): IView<Span> =
+        ViewBuilder.Create(attrs)
+    
+    type Span with
+        static member inlines<'t when 't :> Span>(value: InlineCollection) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<InlineCollection>(Span.InlinesProperty, value, ValueNone)
+            
+        static member inlines<'t when 't :> Span>(values: IView list (* TODO: Change to IView<Inline> *)) : IAttr<'t> =
+            let getter : ('t -> obj) = (fun control -> control.Inlines :> obj)
+            AttrBuilder<'t>.CreateContentMultiple("Inlines", ValueSome getter, ValueNone, values)

--- a/src/Avalonia.FuncUI/DSL/Documents/Underline.fs
+++ b/src/Avalonia.FuncUI/DSL/Documents/Underline.fs
@@ -1,0 +1,19 @@
+namespace Avalonia.FuncUI.DSL
+
+[<AutoOpen>]
+module Underline =  
+    open Avalonia.FuncUI.Builder
+    open Avalonia.FuncUI.Types
+    open Avalonia.Controls.Documents
+
+    let create (attrs: IAttr<Underline> list): IView<Underline> =
+        ViewBuilder.Create(attrs)
+        
+    let simple (text: string): IView<Underline> =
+        ViewBuilder.Create([
+            Underline.inlines [
+                Run.create [
+                    Run.text text
+                ] :> IView
+            ]
+        ])

--- a/src/Avalonia.FuncUI/DSL/Primitives/TextElement.fs
+++ b/src/Avalonia.FuncUI/DSL/Primitives/TextElement.fs
@@ -1,0 +1,41 @@
+namespace Avalonia.FuncUI.DSL
+
+open Avalonia.Controls.Documents
+
+[<AutoOpen>]
+module TextElement =  
+    open Avalonia.Media.Immutable
+    open Avalonia.FuncUI.Types
+    open Avalonia.FuncUI.Builder
+    open Avalonia.Media
+    
+    let create (attrs: IAttr<TextElement> list): IView<TextElement> =
+        ViewBuilder.Create<TextElement>(attrs)
+        
+    type TextElement with
+        static member background<'t when 't :> TextElement>(value: IBrush) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<IBrush>(TextElement.BackgroundProperty, value, ValueNone)
+            
+        static member background<'t when 't :> TextElement>(color: string) : IAttr<'t> =
+            Color.Parse(color) |> ImmutableSolidColorBrush |> TextElement.background
+            
+        static member fontFamily<'t when 't :> TextElement>(value: FontFamily) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<FontFamily>(TextElement.FontFamilyProperty, value, ValueNone)
+            
+        static member fontSize<'t when 't :> TextElement>(value: double) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<double>(TextElement.FontSizeProperty, value, ValueNone)
+            
+        static member fontStyle<'t when 't :> TextElement>(value: FontStyle) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<FontStyle>(TextElement.FontStyleProperty, value, ValueNone)
+            
+        static member fontStretch<'t when 't :> TextElement>(value: FontStretch) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<FontStretch>(TextElement.FontStretchProperty, value, ValueNone)
+
+        static member fontWeight<'t when 't :> TextElement>(value: FontWeight) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<FontWeight>(TextElement.FontWeightProperty, value, ValueNone)
+            
+        static member foreground<'t when 't :> TextElement>(value: IBrush) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<IBrush>(TextElement.ForegroundProperty, value, ValueNone)
+            
+        static member foreground<'t when 't :> TextElement>(color: string) : IAttr<'t> =
+            Color.Parse(color) |> ImmutableSolidColorBrush |> TextElement.foreground

--- a/src/Avalonia.FuncUI/DSL/RichTextBlock.fs
+++ b/src/Avalonia.FuncUI/DSL/RichTextBlock.fs
@@ -1,5 +1,6 @@
 namespace Avalonia.FuncUI.DSL
 
+
 [<AutoOpen>]
 module RichTextBlock =  
     open Avalonia.Controls
@@ -14,10 +15,5 @@ module RichTextBlock =
         static member inlines<'t when 't :> RichTextBlock>(value: InlineCollection) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<InlineCollection>(RichTextBlock.InlinesProperty, value, ValueNone)
             
-        static member inlines<'t when 't :> RichTextBlock>(values: Inline list) : IAttr<'t> =
-            let inlineCollection =
-                let collection = InlineCollection()
-                values |> List.iter collection.Add
-                collection
-            
-            inlineCollection |> RichTextBlock.inlines
+        static member inlines<'t when 't :> RichTextBlock>(values: IInline list) : IAttr<'t> =
+            AttrBuilder<'t>.CreateInlineProperty(RichTextBlock.InlinesProperty, values)

--- a/src/Avalonia.FuncUI/DSL/RichTextBlock.fs
+++ b/src/Avalonia.FuncUI/DSL/RichTextBlock.fs
@@ -15,6 +15,6 @@ module RichTextBlock =
         static member inlines<'t when 't :> RichTextBlock>(value: InlineCollection) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<InlineCollection>(RichTextBlock.InlinesProperty, value, ValueNone)
             
-        static member inlines<'t when 't :> RichTextBlock>(values: IView list (* TODO: Should this view IView<Inline>? *)) : IAttr<'t> =
+        static member inlines<'t when 't :> RichTextBlock>(values: IView list (* TODO: Change to IView<Inline> *)) : IAttr<'t> =
             let getter : ('t -> obj) = (fun control -> control.Inlines :> obj)
             AttrBuilder<'t>.CreateContentMultiple("Inlines", ValueSome getter, ValueNone, values)

--- a/src/Avalonia.FuncUI/DSL/RichTextBlock.fs
+++ b/src/Avalonia.FuncUI/DSL/RichTextBlock.fs
@@ -1,0 +1,23 @@
+namespace Avalonia.FuncUI.DSL
+
+[<AutoOpen>]
+module RichTextBlock =  
+    open Avalonia.Controls
+    open Avalonia.Controls.Documents
+    open Avalonia.FuncUI.Builder
+    open Avalonia.FuncUI.Types
+
+    let create (attrs: IAttr<RichTextBlock> list): IView<RichTextBlock> =
+        ViewBuilder.Create<RichTextBlock>(attrs)
+    
+    type RichTextBlock with
+        static member inlines<'t when 't :> RichTextBlock>(value: InlineCollection) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<InlineCollection>(RichTextBlock.InlinesProperty, value, ValueNone)
+            
+        static member inlines<'t when 't :> RichTextBlock>(values: Inline list) : IAttr<'t> =
+            let inlineCollection =
+                let collection = InlineCollection()
+                values |> List.iter collection.Add
+                collection
+            
+            inlineCollection |> RichTextBlock.inlines

--- a/src/Avalonia.FuncUI/DSL/RichTextBlock.fs
+++ b/src/Avalonia.FuncUI/DSL/RichTextBlock.fs
@@ -15,5 +15,6 @@ module RichTextBlock =
         static member inlines<'t when 't :> RichTextBlock>(value: InlineCollection) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<InlineCollection>(RichTextBlock.InlinesProperty, value, ValueNone)
             
-        static member inlines<'t when 't :> RichTextBlock>(values: IInline list) : IAttr<'t> =
-            AttrBuilder<'t>.CreateInlineProperty(RichTextBlock.InlinesProperty, values)
+        static member inlines<'t when 't :> RichTextBlock>(values: IView list (* TODO: Should this view IView<Inline>? *)) : IAttr<'t> =
+            let getter : ('t -> obj) = (fun control -> control.Inlines :> obj)
+            AttrBuilder<'t>.CreateContentMultiple("Inlines", ValueSome getter, ValueNone, values)

--- a/src/Avalonia.FuncUI/Library.fs
+++ b/src/Avalonia.FuncUI/Library.fs
@@ -35,7 +35,6 @@ module internal Extensions =
 
     type IInteractive with
         member this.GetObservable<'args when 'args :> RoutedEventArgs>(routedEvent: RoutedEvent<'args>) : IObservable<'args> =
-
             let sub = Func<IObserver<'args>, IDisposable>(fun observer ->
                 // push new update to subscribers
                 let handler = EventHandler<'args>(fun _ e ->

--- a/src/Avalonia.FuncUI/Types.fs
+++ b/src/Avalonia.FuncUI/Types.fs
@@ -4,7 +4,6 @@ open Avalonia
 open Avalonia.Controls
 open System
 open System.Threading
-open Avalonia.Interactivity
 
 module Types =
 
@@ -77,24 +76,12 @@ module Types =
 
         override this.GetHashCode () =
             (this.Name, this.FuncType, this.Scope).GetHashCode()
-
-    /// <summary>
-    /// Defines an inline element with the accessor to the property inside the
-    /// control that contains the element itself and the properties of the inline
-    /// element that we are modifying.
-    /// </summary>
-    type Inlines =
-        { /// Reference to the accessor that allows us to modify the host's property that contains the inlines.
-          HostAccessor: AvaloniaProperty
-          /// Reference to all the inlines inside of a host with their attributes.
-          Inlines: IInline list }
     
     type IAttr =
         abstract member UniqueName : string
         abstract member Property : Property option
         abstract member Content : Content option
         abstract member Subscription : Subscription option
-        abstract member Inlines : Inlines option
 
     type IAttr<'viewType> =
         inherit IAttr
@@ -103,7 +90,6 @@ module Types =
         | Property of Property
         | Content of Content
         | Subscription of Subscription
-        | Inline of Inlines
 
         interface IAttr<'viewType>
 
@@ -121,8 +107,6 @@ module Types =
                     | Accessor.InstanceProperty p -> p.Name
 
                 | Subscription subscription -> subscription.Name
-                
-                | Inline inlines -> inlines.HostAccessor.Name
 
             member this.Property =
                 match this with
@@ -138,11 +122,6 @@ module Types =
                 match this with
                 | Subscription value -> Some value
                 | _ -> None
-                
-            member this.Inlines =
-                match this with
-                | Inline value -> Some value
-                | _ -> None
 
     type IView =
         abstract member ViewType: Type with get
@@ -155,13 +134,6 @@ module Types =
         inherit IView
         abstract member Attrs: IAttr<'viewType> list with get
 
-    type IInline =
-        abstract member InlineElement: Avalonia.Controls.Documents.Inline with get
-        abstract member Attrs: IAttr list with get
-        
-    type IInline<'inlineType> =
-        abstract member Attrs: IAttr<'inlineType> list with get
-    
     type View<'viewType> =
         { ViewType: Type
           ViewKey: string voption
@@ -181,18 +153,6 @@ module Types =
         interface IView<'viewType> with
             member this.Attrs = this.Attrs
 
-    type Inline<'inlineType> =
-        { InlineElement: Avalonia.Controls.Documents.Inline
-          Attrs: IAttr<'inlineType> list }
-        
-        interface IInline with
-            member this.InlineElement = this.InlineElement
-            member this.Attrs =
-                this.Attrs |> List.map (fun attr -> attr :> IAttr)
-                
-        interface IInline<'inlineType> with
-            member this.Attrs = this.Attrs
-
     // TODO: maybe move active patterns to Virtual DON Misc
 
     let internal (|Property'|_|) (attr: IAttr)  =
@@ -203,7 +163,4 @@ module Types =
 
     let internal (|Subscription'|_|) (attr: IAttr)  =
         attr.Subscription
-        
-    let internal (|Inlines'|_|) (attr: IAttr) =
-        attr.Inlines
     

--- a/src/Avalonia.FuncUI/Types.fs
+++ b/src/Avalonia.FuncUI/Types.fs
@@ -1,5 +1,6 @@
 ﻿namespace rec Avalonia.FuncUI
 
+open Avalonia
 open Avalonia.Controls
 open System
 open System.Reactive.Linq
@@ -10,8 +11,8 @@ module Types =
     [<CustomEquality; NoComparison>]
     type PropertyAccessor =
         { Name: string
-          Getter: (IControl -> obj) voption
-          Setter: (IControl * obj -> unit) voption }
+          Getter: (IAvaloniaObject -> obj) voption
+          Setter: (IAvaloniaObject * obj -> unit) voption }
 
         override this.Equals (other: obj) : bool =
             match other with

--- a/src/Avalonia.FuncUI/Types.fs
+++ b/src/Avalonia.FuncUI/Types.fs
@@ -4,6 +4,7 @@ open Avalonia
 open Avalonia.Controls
 open System
 open System.Threading
+open Avalonia.Interactivity
 
 module Types =
 
@@ -61,7 +62,7 @@ module Types =
     [<CustomEquality; NoComparison>]
     type Subscription =
         { Name: string
-          Subscribe:  IControl * Delegate -> CancellationTokenSource
+          Subscribe: IControl  * Delegate -> CancellationTokenSource
           Func: Delegate
           FuncType: Type
           Scope: obj }
@@ -148,7 +149,7 @@ module Types =
         abstract member ViewKey: string voption
         abstract member Attrs: IAttr list with get
         abstract member ConstructorArgs: obj array with get
-        abstract member Outlet: (IControl -> unit) voption with get
+        abstract member Outlet: (IAvaloniaObject -> unit) voption with get
 
     type IView<'viewType> =
         inherit IView
@@ -166,7 +167,7 @@ module Types =
           ViewKey: string voption
           Attrs: IAttr<'viewType> list
           ConstructorArgs: obj array
-          Outlet: (IControl -> unit) voption }
+          Outlet: (IAvaloniaObject-> unit) voption }
 
         interface IView with
             member this.ViewType =  this.ViewType

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Delta.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Delta.fs
@@ -13,14 +13,12 @@ module internal rec Delta =
         | Property of PropertyDelta
         | Content of ContentDelta
         | Subscription of SubscriptionDelta
-        | Inline of InlineDelta
 
         static member From (attr: IAttr) : AttrDelta =
             match attr with
             | Property' property -> Property (PropertyDelta.From property)
             | Content' content -> Content (ContentDelta.From content)
             | Subscription' subscription -> Subscription (SubscriptionDelta.From subscription)
-            | Inlines' inlineElement -> Inline (InlineDelta.From inlineElement)
             | _ -> raise (Exception "unknown IAttr type. (not a Property, Content ore Subscription attribute)")
 
 
@@ -76,21 +74,6 @@ module internal rec Delta =
             { Accessor = content.Accessor;
               Content = ViewContentDelta.From content.Content }
             
-    type InlineDelta =
-        { HostAccessor: Avalonia.AvaloniaProperty
-          Inlines: (Avalonia.Controls.Documents.Inline * AttrDelta list) list }
-        
-        static member From (inlineElement: Inlines) : InlineDelta =
-            { HostAccessor = inlineElement.HostAccessor
-              Inlines =
-                  inlineElement.Inlines
-                 |> List.map (fun inl ->
-                     let deltas =
-                         inl.Attrs
-                         |> List.map AttrDelta.From
-                     
-                     (inl.InlineElement, deltas)) }
-
     type ViewContentDelta =
         | Single of ViewDelta option
         | Multiple of ViewDelta list

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Delta.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Delta.fs
@@ -3,6 +3,8 @@ namespace Avalonia.FuncUI.VirtualDom
 open System
 open System.Threading
 
+open Avalonia
+open Avalonia.Controls
 open Avalonia.FuncUI.Types
 
 module internal rec Delta =
@@ -47,7 +49,7 @@ module internal rec Delta =
     [<CustomEquality; NoComparison>]
     type SubscriptionDelta =
         { Name: string
-          Subscribe: Avalonia.Controls.IControl * Delegate -> CancellationTokenSource
+          Subscribe: IControl * Delegate -> CancellationTokenSource
           Func: Delegate option }
 
         override this.Equals (other: obj) : bool =
@@ -116,7 +118,7 @@ module internal rec Delta =
           Attrs: AttrDelta list
           ConstructorArgs: obj array
           KeyDidChange: bool
-          Outlet: (Avalonia.Controls.IControl -> unit) voption }
+          Outlet: (Avalonia.IAvaloniaObject -> unit) voption }
 
         static member From (view: IView, ?keyDidChange: bool) : ViewDelta =
             { ViewType = view.ViewType

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Differ.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Differ.fs
@@ -1,8 +1,7 @@
 namespace Avalonia.FuncUI.VirtualDom
 
-open System.Collections.Generic
 open Avalonia.FuncUI.Types
-open Delta
+open Avalonia.FuncUI.VirtualDom.Delta
 
 module internal rec Differ =
     let private update (last: IAttr) (next: IAttr) : AttrDelta =
@@ -21,6 +20,9 @@ module internal rec Differ =
         | Subscription' subscription ->
             AttrDelta.Subscription (SubscriptionDelta.From subscription)
 
+        | Inlines' inlineElement ->
+            AttrDelta.Inline (InlineDelta.From inlineElement)
+        
         | _ -> failwithf "no update operation is defined for '%A' next" next
 
     let private reset (last: IAttr) : AttrDelta =

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Differ.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Differ.fs
@@ -20,9 +20,6 @@ module internal rec Differ =
         | Subscription' subscription ->
             AttrDelta.Subscription (SubscriptionDelta.From subscription)
 
-        | Inlines' inlineElement ->
-            AttrDelta.Inline (InlineDelta.From inlineElement)
-        
         | _ -> failwithf "no update operation is defined for '%A' next" next
 
     let private reset (last: IAttr) : AttrDelta =

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Misc.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Misc.fs
@@ -19,16 +19,16 @@ type ViewMetaData() =
 
     static member ViewSubscriptionsProperty = viewSubscriptions
 
-    static member GetViewId(control: IControl) : Guid =
+    static member GetViewId(control: IAvaloniaObject) : Guid =
         control.GetValue(ViewMetaData.ViewIdProperty)
 
-    static member SetViewId(control: IControl, value: Guid) : unit =
+    static member SetViewId(control: IAvaloniaObject, value: Guid) : unit =
         control.SetValue(ViewMetaData.ViewIdProperty, value) |> ignore
 
-    static member GetViewSubscriptions(control: IControl) : ConcurrentDictionary<_, _> =
+    static member GetViewSubscriptions(control: IAvaloniaObject) : ConcurrentDictionary<_, _> =
         control.GetValue(ViewMetaData.ViewSubscriptionsProperty)
 
-    static member SetViewSubscriptions(control: IControl, value) : unit =
+    static member SetViewSubscriptions(control: IAvaloniaObject, value) : unit =
         control.SetValue(ViewMetaData.ViewSubscriptionsProperty, value) |> ignore
 
 

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Patcher.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Patcher.fs
@@ -46,7 +46,7 @@ module internal rec Patcher =
                 value.Cancel()
                 subscriptions.TryRemove(attr.UniqueName) |> ignore
 
-    let private patchProperty (view: IControl) (attr: PropertyDelta) : unit =
+    let internal patchProperty (view: IAvaloniaObject) (attr: PropertyDelta) : unit =
         match attr.Accessor with
         | Accessor.AvaloniaProperty avaloniaProperty ->
             match attr.Value with

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Patcher.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Patcher.fs
@@ -209,24 +209,6 @@ module internal rec Patcher =
         | ViewContentDelta.Multiple multiple ->
             patchContentMultiple view attr.Accessor multiple
             
-    let private patchInline (view: IAvaloniaObject) (attr: InlineDelta) : unit =
-        let inlineCollection = InlineCollection()
-        
-        attr.Inlines
-        |> List.iter (fun (element, deltas) ->
-            (* Path all properties from the inline element. *)
-            deltas
-            |> List.iter (function
-                | AttrDelta.Property property -> patchProperty element property
-                | _ -> failwith "Only properties are supported in inline elements"   
-            )
-            
-            inlineCollection.Add element
-        )
-        
-        (* Update the host property. TODO: Is this really needed once we set them initially? *)
-        view.SetValue(attr.HostAccessor, inlineCollection) |> ignore
-
     let patch (view: IAvaloniaObject, viewElement: ViewDelta) : unit =
         for attr in viewElement.Attrs do
             match attr with
@@ -237,7 +219,6 @@ module internal rec Patcher =
                 | :? IControl as control -> 
                     patchSubscription control subscription
                 | _ -> failwith "Only controls can have subscriptions"
-            | AttrDelta.Inline inlineElement -> patchInline view inlineElement
 
     let create (viewElement: ViewDelta) : IAvaloniaObject =
         let control =

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.fs
@@ -10,7 +10,7 @@ module rec VirtualDom =
     let create (view: IView) : IControl =
         view
         |> ViewDelta.From
-        |> Patcher.create :?> IControl (* TODO: Can we remove this cast? *)
+        |> Patcher.create :?> IControl
 
     let update (root: IControl, last: IView, next: IView) : unit =
         let delta = Differ.diff(last, next)
@@ -76,11 +76,11 @@ module rec VirtualDom =
             | ValueSome delta ->
                 match control.GetType () = delta.ViewType && not delta.KeyDidChange with
                 | true -> Patcher.patch (control, delta)
-                | false -> host.Child <- (Patcher.create delta) :?> IControl (* TODO: Can we remove this cast? *)
+                | false -> host.Child <- (Patcher.create delta) :?> IControl
             | ValueNone ->
                 host.Child <- null
 
         | ValueNone ->
             match delta with
-            | ValueSome delta -> host.Child <- (Patcher.create delta) :?> IControl (* TODO: Can we remove this cast? *)
+            | ValueSome delta -> host.Child <- (Patcher.create delta) :?> IControl
             | ValueNone -> host.Child <- null

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.fs
@@ -10,7 +10,7 @@ module rec VirtualDom =
     let create (view: IView) : IControl =
         view
         |> ViewDelta.From
-        |> Patcher.create
+        |> Patcher.create :?> IControl (* TODO: Can we remove this cast? *)
 
     let update (root: IControl, last: IView, next: IView) : unit =
         let delta = Differ.diff(last, next)
@@ -76,11 +76,11 @@ module rec VirtualDom =
             | ValueSome delta ->
                 match control.GetType () = delta.ViewType && not delta.KeyDidChange with
                 | true -> Patcher.patch (control, delta)
-                | false -> host.Child <- Patcher.create delta
+                | false -> host.Child <- (Patcher.create delta) :?> IControl (* TODO: Can we remove this cast? *)
             | ValueNone ->
                 host.Child <- null
 
         | ValueNone ->
             match delta with
-            | ValueSome delta -> host.Child <- Patcher.create delta
+            | ValueSome delta -> host.Child <- (Patcher.create delta) :?> IControl (* TODO: Can we remove this cast? *)
             | ValueNone -> host.Child <- null

--- a/src/Examples/Component Examples/Examples.InlineText/Examples.InlineText.fsproj
+++ b/src/Examples/Component Examples/Examples.InlineText/Examples.InlineText.fsproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="View.fs" />
+        <Compile Include="Program.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
+        <ProjectReference Include="..\..\..\Avalonia.FuncUI\Avalonia.FuncUI.fsproj" />
+        <ProjectReference Include="..\..\..\Avalonia.FuncUI.Diagnostics\Avalonia.FuncUI.Diagnostics.fsproj" />
+        <ProjectReference Include="..\..\..\Avalonia.FuncUI.Elmish\Avalonia.FuncUI.Elmish.fsproj" />
+    </ItemGroup>
+</Project>

--- a/src/Examples/Component Examples/Examples.InlineText/Program.fs
+++ b/src/Examples/Component Examples/Examples.InlineText/Program.fs
@@ -1,0 +1,40 @@
+﻿namespace Examples.InlineText
+
+open Avalonia
+open Avalonia.Controls.ApplicationLifetimes
+open Avalonia.Themes.Fluent
+open Avalonia.FuncUI.Hosts
+
+type MainWindow() as this =
+    inherit HostWindow()
+    do
+        base.Title <- "Examples.InlineText"
+        base.Width <- 400.0
+        base.Height <- 400.0
+        this.Content <- View.view
+
+        //this.VisualRoot.VisualRoot.Renderer.DrawFps <- true
+        //this.VisualRoot.VisualRoot.Renderer.DrawDirtyRects <- true
+
+        
+type App() =
+    inherit Application()
+
+    override this.Initialize() =
+        this.Styles.Add (FluentTheme(baseUri = null, Mode = FluentThemeMode.Dark))
+
+    override this.OnFrameworkInitializationCompleted() =
+        match this.ApplicationLifetime with
+        | :? IClassicDesktopStyleApplicationLifetime as desktopLifetime ->
+            desktopLifetime.MainWindow <- MainWindow()
+        | _ -> ()
+
+module Program =
+
+    [<EntryPoint>]
+    let main(args: string[]) =
+        AppBuilder
+            .Configure<App>()
+            .UsePlatformDetect()
+            .UseSkia()
+            .StartWithClassicDesktopLifetime(args)

--- a/src/Examples/Component Examples/Examples.InlineText/Program.fs
+++ b/src/Examples/Component Examples/Examples.InlineText/Program.fs
@@ -9,7 +9,7 @@ type MainWindow() as this =
     inherit HostWindow()
     do
         base.Title <- "Examples.InlineText"
-        base.Width <- 400.0
+        base.Width <- 1200.0
         base.Height <- 400.0
         this.Content <- View.view
 

--- a/src/Examples/Component Examples/Examples.InlineText/View.fs
+++ b/src/Examples/Component Examples/Examples.InlineText/View.fs
@@ -14,25 +14,12 @@ module View =
         Component (fun ctx ->
             let colorMode = ctx.useState 0
 
-            let inlineItem =
-                let x = Run("Inline")
-                let brush =
-                    if colorMode.Current = 0 then
-                        0x0ffB2474Du
-                    else
-                        0x0ff47B2A6u
-                    |> Color.FromUInt32
-                    |> ImmutableSolidColorBrush
-                
-                x.Background <- brush
-                x
-
             StackPanel.create [
                 StackPanel.verticalAlignment VerticalAlignment.Center
                 StackPanel.horizontalAlignment HorizontalAlignment.Center
                 StackPanel.children [
                     Button.create [
-                        Button.content "Flip color!"
+                        Button.content "Invert color!"
                         Button.onClick (fun _ ->
                             if colorMode.Current = 0 then
                                 colorMode.Set 1
@@ -44,8 +31,19 @@ module View =
                         RichTextBlock.fontSize 48.0
                         RichTextBlock.horizontalAlignment HorizontalAlignment.Center
                         RichTextBlock.inlines [
-                            Run("You") :> Inline
-                            inlineItem
+                            Run.create [
+                                Run.text "You"
+                            ]
+                            Run.create [
+                                Run.text "Inline"
+                                if colorMode.Current = 0 then
+                                    0x0ffB2474Du
+                                else
+                                    0x0ff47B2A6u
+                                |> Color.FromUInt32
+                                |> ImmutableSolidColorBrush
+                                |> Run.background
+                            ]
                         ]
                     ]
                 ]

--- a/src/Examples/Component Examples/Examples.InlineText/View.fs
+++ b/src/Examples/Component Examples/Examples.InlineText/View.fs
@@ -1,14 +1,14 @@
 ﻿namespace Examples.InlineText
 
-open Avalonia.FuncUI.DSL
-open Avalonia.Media
-open Avalonia.Media.Immutable
-
 module View =
-    open Avalonia.Controls
-    open Avalonia.Controls.Documents
+    open Avalonia.FuncUI.DSL
+    open Avalonia.FuncUI.Types
     open Avalonia.FuncUI
+    open Avalonia.Controls
     open Avalonia.Layout
+    open Avalonia.Media
+    open Avalonia.Media.Immutable
+    open Avalonia.Controls.Documents
 
     let view =
         Component (fun ctx ->
@@ -33,7 +33,7 @@ module View =
                         RichTextBlock.inlines [
                             Run.create [
                                 Run.text "You"
-                            ]
+                            ] :> IInline
                             Run.create [
                                 Run.text "Inline"
                                 if colorMode.Current = 0 then

--- a/src/Examples/Component Examples/Examples.InlineText/View.fs
+++ b/src/Examples/Component Examples/Examples.InlineText/View.fs
@@ -10,6 +10,9 @@ module View =
     open Avalonia.Media.Immutable
     open Avalonia.Controls.Documents
 
+    let private redBrush = 0x0ffB2474Du |> Color.FromUInt32 |> ImmutableSolidColorBrush
+    let private blueBrush = 0x0ff47B2A6u |> Color.FromUInt32 |> ImmutableSolidColorBrush
+    
     let view =
         Component (fun ctx ->
             let colorMode = ctx.useState 0
@@ -37,11 +40,9 @@ module View =
                             Run.create [
                                 Run.text "Inline"
                                 if colorMode.Current = 0 then
-                                    0x0ffB2474Du
+                                    redBrush   
                                 else
-                                    0x0ff47B2A6u
-                                |> Color.FromUInt32
-                                |> ImmutableSolidColorBrush
+                                    blueBrush
                                 |> Run.background
                             ]
                             

--- a/src/Examples/Component Examples/Examples.InlineText/View.fs
+++ b/src/Examples/Component Examples/Examples.InlineText/View.fs
@@ -1,0 +1,52 @@
+﻿namespace Examples.InlineText
+
+open Avalonia.FuncUI.DSL
+open Avalonia.Media
+open Avalonia.Media.Immutable
+
+module View =
+    open Avalonia.Controls
+    open Avalonia.Controls.Documents
+    open Avalonia.FuncUI
+    open Avalonia.Layout
+
+    let view =
+        Component (fun ctx ->
+            let colorMode = ctx.useState 0
+
+            let inlineItem =
+                let x = Run("Inline")
+                let brush =
+                    if colorMode.Current = 0 then
+                        0x0ffB2474Du
+                    else
+                        0x0ff47B2A6u
+                    |> Color.FromUInt32
+                    |> ImmutableSolidColorBrush
+                
+                x.Background <- brush
+                x
+
+            StackPanel.create [
+                StackPanel.verticalAlignment VerticalAlignment.Center
+                StackPanel.horizontalAlignment HorizontalAlignment.Center
+                StackPanel.children [
+                    Button.create [
+                        Button.content "Flip color!"
+                        Button.onClick (fun _ ->
+                            if colorMode.Current = 0 then
+                                colorMode.Set 1
+                            else
+                                colorMode.Set 0)
+                    ]
+                    RichTextBlock.create [
+                        RichTextBlock.dock Dock.Top
+                        RichTextBlock.fontSize 48.0
+                        RichTextBlock.horizontalAlignment HorizontalAlignment.Center
+                        RichTextBlock.inlines [
+                            Run("You") :> Inline
+                            inlineItem
+                        ]
+                    ]
+                ]
+            ])

--- a/src/Examples/Component Examples/Examples.InlineText/View.fs
+++ b/src/Examples/Component Examples/Examples.InlineText/View.fs
@@ -33,7 +33,7 @@ module View =
                         RichTextBlock.inlines [
                             Run.create [
                                 Run.text "You"
-                            ] :> IInline
+                            ] :> IView
                             Run.create [
                                 Run.text "Inline"
                                 if colorMode.Current = 0 then

--- a/src/Examples/Component Examples/Examples.InlineText/View.fs
+++ b/src/Examples/Component Examples/Examples.InlineText/View.fs
@@ -44,6 +44,21 @@ module View =
                                 |> ImmutableSolidColorBrush
                                 |> Run.background
                             ]
+                            
+                            LineBreak.simple
+                            
+                            Span.create [
+                                Span.inlines [
+                                    Bold.simple "Oh, so bold!" :> IView
+                                    LineBreak.simple
+                                    
+                                    Italic.simple "Although, "
+                                    Run.create [
+                                        Run.text "I always wanted to be "
+                                    ]
+                                    Underline.simple "underlined"
+                                ]
+                            ]
                         ]
                     ]
                 ]


### PR DESCRIPTION
This PR attempts to add support for the new RichTextBlock introduced in Avalonia v11. Although adding the new control is pretty straightforward, the main challenge comes from the new inline elements that were introduced for the new control, since these should be used the same way as controls are used but are not controls per se.

## How the new elements work
The new control contains a property with a collection of [Inlines](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Documents/Inline.cs), which are themselves subclasses of StyledElements. Each inline then defines how that portion of the text should be styled, with `Run` being a portion of text and `Span` being a group for other inline elements. All these are then collected by the control and rendered.

## Implementation for FuncUI
For a comprehensive demo of all the elements take a look at the new example I created 😄 

## Demo time!
![Inline](https://user-images.githubusercontent.com/6024783/195993774-205fd4f6-3e82-4ee5-ae3a-0d142dbcc692.gif)

## To Do
- [x] Add styling support for [Run](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Documents/Run.cs)
- [x] Add bindings for [Span](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Documents/Span.cs)
- [x] Add bindings for [Bold](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Documents/Bold.cs)
- [x] Add bindings for [Italic](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Documents/Italic.cs)
- [x] Add bindings for [Underline](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Documents/Underline.cs)
- [x] Add bindings for [LineBreak](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Documents/LineBreak.cs)
- [x] Validate that the patcher changes don't break anything (so far I've just run a couple of examples, but I'd like to validate the rest)
- [ ] Check how can we make inline elements be `IView<Inline>` instead of the non-generic `IView` while preventing unnecessary castings