### PR TITLE
Add `simple` function to Run elements

### DIFF
--- a/src/Avalonia.FuncUI/DSL/Documents/Run.fs
+++ b/src/Avalonia.FuncUI/DSL/Documents/Run.fs
@@ -11,3 +11,5 @@ module Run =
     type Run with
         static member text<'t when 't :> Run>(value: string) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<string>(Run.TextProperty, value, ValueNone)
+
+    let simple (text: string) : IView<Run> = ViewBuilder.Create([ Run.text text ])

--- a/src/Examples/Component Examples/Examples.InlineText/View.fs
+++ b/src/Examples/Component Examples/Examples.InlineText/View.fs
@@ -34,9 +34,7 @@ module View =
                         RichTextBlock.fontSize 48.0
                         RichTextBlock.horizontalAlignment HorizontalAlignment.Center
                         RichTextBlock.inlines [
-                            Run.create [
-                                Run.text "You"
-                            ] :> IView
+                            Run.simple "You" :> IView
                             Run.create [
                                 Run.text "Inline"
                                 if colorMode.Current = 0 then


### PR DESCRIPTION
Super simple change that somehow I forgot to add when in #220. This follows the same convention as Bold, LineBreak, etc.