### PR TITLE
Fix MaskedTextBox attributes

### DIFF
--- a/src/Avalonia.FuncUI/DSL/MaskedTextBox.fs
+++ b/src/Avalonia.FuncUI/DSL/MaskedTextBox.fs
@@ -6,11 +6,11 @@ module MaskedTextBox =
     open Avalonia.FuncUI.Builder
     open Avalonia.FuncUI.Types
 
-    let create (attrs: IAttr<TextBox> list): IView<TextBox> =
-        ViewBuilder.Create<TextBox> attrs
+    let create (attrs: IAttr<MaskedTextBox> list): IView<MaskedTextBox> =
+        ViewBuilder.Create<MaskedTextBox> attrs
 
-    let createFromProvider (provider: System.ComponentModel.MaskedTextProvider) (attrs: IAttr<TextBox> list): IView<TextBox> =
-        ViewBuilder.Create<TextBox> attrs
+    let createFromProvider (provider: System.ComponentModel.MaskedTextProvider) (attrs: IAttr<MaskedTextBox> list): IView<MaskedTextBox> =
+        ViewBuilder.Create<MaskedTextBox> attrs
         |> View.withConstructorArgs [|provider|]
 
     type MaskedTextBox with

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <AvaloniaVersion>11.0.0-preview2</AvaloniaVersion>
-    <FuncUIVersion>0.6.0-preview2</FuncUIVersion>
+    <FuncUIVersion>0.6.0-preview3</FuncUIVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The control bindings introduced in #217 do not accept `MaskedTextBox` attributes currently because the attrs parameter is set to `TextBox`. Changing to `MaskedTextBox` accepts both, since the later already inherits from `TextBox` anyway.

Edited the contacts example to display this masked text box with a mask:

<img width="532" alt="image" src="https://user-images.githubusercontent.com/6024783/197894368-897fe243-f524-4bb2-aef9-deea386b8eeb.png">

_(Won't be uploading this since some of the phone numbers don't follow that format and they don't work correctly, but it shows that the bindings work as the `mask` property is only available on `MaskedTextBox` and it was not being accepted before)_

Also bumping the preview version since I need this on one of my projects 😃 