### PR TITLE
Remove the header properties from DatePicker and TimePicker

### DIFF
--- a/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/DatePickerDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/DatePickerDemo.fs
@@ -54,23 +54,31 @@ module DatePickerDemo =
         Grid.create [
             Grid.rowDefinitions "Auto, *"
             Grid.children [
-                DatePicker.create [
+                StackPanel.create [
                     Grid.row 0
 
-                    DatePicker.dayVisible state.isDayVisible
-                    DatePicker.monthVisible state.isMonthVisible
-                    DatePicker.yearVisible state.isYearVisible
+                    StackPanel.children [
+                        TextBlock.create [
+                            TextBlock.text state.header
+                        ]
 
-                    DatePicker.dayFormat state.dayFormat
-                    DatePicker.monthFormat state.monthFormat
-                    DatePicker.yearFormat state.yearFormat
+                        DatePicker.create [
 
-                    DatePicker.header state.header
-                    DatePicker.selectedDate state.date
+                            DatePicker.dayVisible state.isDayVisible
+                            DatePicker.monthVisible state.isMonthVisible
+                            DatePicker.yearVisible state.isYearVisible
 
-                    DatePicker.onSelectedDateChanged (
-                        Msg.SetDate >> dispatch
-                    )
+                            DatePicker.dayFormat state.dayFormat
+                            DatePicker.monthFormat state.monthFormat
+                            DatePicker.yearFormat state.yearFormat
+
+                            DatePicker.selectedDate state.date
+
+                            DatePicker.onSelectedDateChanged (
+                                Msg.SetDate >> dispatch
+                            )
+                        ]
+                    ]
                 ]
                 
                 StackPanel.create [

--- a/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/TimePickerDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/TimePickerDemo.fs
@@ -38,11 +38,14 @@ module TimePickerDemo =
         StackPanel.create [
             StackPanel.spacing 7.0
             StackPanel.children [
+                TextBlock.create [
+                    TextBlock.text state.header
+                ]
+
                 TimePicker.create [
                     TimePicker.clockIdentifier state.clockIdentifier
                     TimePicker.minuteIncrement state.minuteIncrement
 
-                    TimePicker.header state.header
                     TimePicker.selectedTime state.time
 
                     TimePicker.onSelectedTimeChanged (

--- a/src/Avalonia.FuncUI/DSL/DatePicker.fs
+++ b/src/Avalonia.FuncUI/DSL/DatePicker.fs
@@ -49,9 +49,4 @@ module DatePicker =
         static member maxYear<'t when 't :> DatePicker>(value: DateTimeOffset) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<DateTimeOffset>(DatePicker.MaxYearProperty, value, ValueNone)
 
-        static member header<'t when 't :> DatePicker>(value: obj) : IAttr<'t> =
-            AttrBuilder<'t>.CreateProperty<obj>(DatePicker.HeaderProperty, value, ValueNone)
-        
-        static member headerTemplate<'t when 't :> DatePicker>(template: IDataTemplate) : IAttr<'t> =
-            AttrBuilder<'t>.CreateProperty<IDataTemplate>(DatePicker.HeaderTemplateProperty, template, ValueNone)
         

--- a/src/Avalonia.FuncUI/DSL/TimePicker.fs
+++ b/src/Avalonia.FuncUI/DSL/TimePicker.fs
@@ -16,12 +16,6 @@ module TimePicker =
         static member clockIdentifier<'t when 't :> TimePicker>(value: string) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<string>(TimePicker.ClockIdentifierProperty, value, ValueNone)
         
-        static member header<'t when 't :> TimePicker>(value: obj) : IAttr<'t> =
-            AttrBuilder<'t>.CreateProperty<obj>(TimePicker.HeaderProperty, value, ValueNone)
-        
-        static member headerTemplate<'t when 't :> TimePicker>(template: IDataTemplate) : IAttr<'t> =
-            AttrBuilder<'t>.CreateProperty<IDataTemplate>(TimePicker.HeaderTemplateProperty, template, ValueNone)
-        
         static member minuteIncrement<'t when 't :> TimePicker>(value: int) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<int>(TimePicker.MinuteIncrementProperty, value, ValueNone)
         


### PR DESCRIPTION
I was looking at #232 and then also fell over https://github.com/AvaloniaUI/Avalonia/issues/9136, for which the header properties have been removed from the DatePicker and TimePicker controls.

So - this removes those.

That also required changes to the control catalog (I changed it to put a text block above the sample date/time controls to contain the header text)