### PR TITLE
Transform comparison

### DIFF
--- a/src/Avalonia.FuncUI/DSL/Base/Visual.fs
+++ b/src/Avalonia.FuncUI/DSL/Base/Visual.fs
@@ -4,6 +4,7 @@ namespace Avalonia.FuncUI.DSL
 module Visual =  
     open Avalonia
     open Avalonia.Media
+    open Avalonia.FuncUI
     open Avalonia.FuncUI.Types
     open Avalonia.FuncUI.Builder
             
@@ -25,7 +26,7 @@ module Visual =
             AttrBuilder<'t>.CreateProperty<IBrush>(Visual.OpacityMaskProperty, value, ValueNone)
 
         static member renderTransform<'t when 't :> Visual>(transform: ITransform) : IAttr<'t> =
-            AttrBuilder<'t>.CreateProperty<ITransform>(Visual.RenderTransformProperty, transform, ValueNone)
+            AttrBuilder<'t>.CreateProperty<ITransform>(Visual.RenderTransformProperty, transform, ValueSome EqualityComparers.compareTransforms)
     
         static member renderTransformOrigin<'t when 't :> Visual>(origin: RelativePoint) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<RelativePoint>(Visual.RenderTransformOriginProperty, origin, ValueNone)

--- a/src/Avalonia.FuncUI/DSL/LayoutTransformControl.fs
+++ b/src/Avalonia.FuncUI/DSL/LayoutTransformControl.fs
@@ -4,6 +4,7 @@
 module LayoutTransformControl =
     open Avalonia.Media
     open Avalonia.Controls
+    open Avalonia.FuncUI
     open Avalonia.FuncUI.Types
     open Avalonia.FuncUI.Builder
    
@@ -12,7 +13,7 @@ module LayoutTransformControl =
 
     type LayoutTransformControl with
         static member layoutTransform<'t when 't :> LayoutTransformControl>(value: ITransform) : IAttr<'t> =
-            AttrBuilder<'t>.CreateProperty<ITransform>(LayoutTransformControl.LayoutTransformProperty, value, ValueNone)
+            AttrBuilder<'t>.CreateProperty<ITransform>(LayoutTransformControl.LayoutTransformProperty, value, ValueSome EqualityComparers.compareTransforms)
             
         static member useRenderTransform<'t when 't :> LayoutTransformControl>(value: bool) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<bool>(LayoutTransformControl.UseRenderTransformProperty, value, ValueNone)

--- a/src/Avalonia.FuncUI/Helpers.fs
+++ b/src/Avalonia.FuncUI/Helpers.fs
@@ -18,3 +18,12 @@ module AvaloniaExtensions =
             let style = StyleInclude(baseUri = null)
             style.Source <- Uri(source)
             this.Add(style)
+            
+module internal EqualityComparers =
+    open Avalonia.Media
+
+    let compareTransforms (t1: obj, t2: obj) =
+        match t1, t2 with
+        | :? ITransform as t1, (:? ITransform as t2) when t1.GetType() = t2.GetType() ->
+            t1.Value.Equals(t2.Value)
+        | _ -> false

--- a/src/Examples/Component Examples/Examples.Presso/Program.fs
+++ b/src/Examples/Component Examples/Examples.Presso/Program.fs
@@ -1,13 +1,10 @@
 ﻿namespace Examples.Presso
 
-open Elmish
 open Avalonia
 open Avalonia.Controls.ApplicationLifetimes
 open Avalonia.Themes.Fluent
 open Avalonia.FuncUI
-open Avalonia.FuncUI.Elmish
 open Avalonia.FuncUI.Hosts
-open Avalonia.Media
 
 type MainWindow() as this =
     inherit HostWindow()


### PR DESCRIPTION
Provided a custom equality comparer for types implementing the `ITransform` interface. 
Types implementing the `ITransform` don't override equality methods, so using them in FuncUI means reassignments on every view generation (if transforms are created on the fly instead of reusing the same instance, producing an object not equal to the previous one even if it's created with the same constructor arguments as default `Equals` compares references). And such reassignment means an additional layout/redraw pass.