### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/Avalonia.FuncUI.ControlCatalog/Views/MainView.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/MainView.fs
@@ -21,7 +21,7 @@ module MainView =
         match msg with
         | DataTemplateDemoMsg msg -> { state with dataTemplateState = DataTemplateDemo.update msg state.dataTemplateState }
 
-    let view (state: CounterState) (dispatch) =
+    let view (state: CounterState) dispatch =
         TabControl.create [
             TabControl.tabStripPlacement Dock.Left
             TabControl.viewItems [

--- a/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/CalendarDatePickerDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/CalendarDatePickerDemo.fs
@@ -6,7 +6,6 @@ open Avalonia.Controls
 open Avalonia.Layout
 open Avalonia.FuncUI
 open Avalonia.FuncUI.DSL
-open Avalonia.FuncUI
 open Avalonia.FuncUI.Elmish
 
 module CalendarDatePickerDemo =

--- a/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/DatePickerDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/DatePickerDemo.fs
@@ -5,7 +5,6 @@ open Elmish
 open Avalonia.Controls
 open Avalonia.FuncUI
 open Avalonia.FuncUI.DSL
-open Avalonia.FuncUI
 open Avalonia.FuncUI.Elmish
 
 module DatePickerDemo =

--- a/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/GridPatchDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/GridPatchDemo.fs
@@ -37,7 +37,8 @@ module GridPatchDemo =
                     yield
                         match state.orientation with
                         | Orientation.Horizontal -> Grid.rowDefinitions "*, *"
-                        | Orientation.Vertical -> Grid.columnDefinitions "*, *"
+                        | Orientation.Vertical
+                        | _ -> Grid.columnDefinitions "*, *"
                     
                     yield Grid.showGridLines true
                     yield Grid.children [
@@ -49,7 +50,8 @@ module GridPatchDemo =
                             yield
                                 match state.orientation with
                                 | Orientation.Horizontal -> Border.row 1
-                                | Orientation.Vertical -> Border.column 1
+                                | Orientation.Vertical
+                                | _ -> Border.column 1
                         ]
                     ]
                 ]

--- a/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/SplitViewDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/SplitViewDemo.fs
@@ -6,7 +6,6 @@ open Avalonia.Layout
 open Avalonia.Media
 open Avalonia.FuncUI
 open Avalonia.FuncUI.DSL
-open Avalonia.FuncUI
 open Avalonia.FuncUI.Elmish
 open System
 

--- a/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/StylesDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/StylesDemo.fs
@@ -6,7 +6,6 @@ open Avalonia.Controls.Presenters
 open Elmish
 open Avalonia.FuncUI
 open Avalonia.FuncUI.DSL
-open Avalonia.FuncUI
 open Avalonia.FuncUI.Elmish
 open Avalonia.Styling
 

--- a/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/TextBoxDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/TextBoxDemo.fs
@@ -5,7 +5,6 @@ open Avalonia.Layout
 open Elmish
 open Avalonia.FuncUI
 open Avalonia.FuncUI.DSL
-open Avalonia.FuncUI
 open Avalonia.FuncUI.Elmish
 
 module TextBoxDemo =

--- a/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/TickBarDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/TickBarDemo.fs
@@ -7,7 +7,6 @@ open Avalonia.Layout
 open Avalonia.Media
 open Avalonia.FuncUI
 open Avalonia.FuncUI.DSL
-open Avalonia.FuncUI
 open Avalonia.FuncUI.Elmish
 
 module TickBarDemo =

--- a/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/TimePickerDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/TimePickerDemo.fs
@@ -5,7 +5,6 @@ open Elmish
 open Avalonia.Controls
 open Avalonia.FuncUI
 open Avalonia.FuncUI.DSL
-open Avalonia.FuncUI
 open Avalonia.FuncUI.Elmish
 
 module TimePickerDemo =

--- a/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/ToggleSwitchDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/ToggleSwitchDemo.fs
@@ -1,6 +1,5 @@
 ﻿namespace Avalonia.FuncUI.ControlCatalog.Views
 
-open System
 open Elmish
 open Avalonia.Controls
 open Avalonia.FuncUI.DSL

--- a/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/WrapPanelDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/WrapPanelDemo.fs
@@ -59,7 +59,7 @@ module WrapPanelDemo =
                         with ex -> Console.WriteLine(ex) 
                     )
                 ]
-                CheckBox.create[
+                CheckBox.create [
                     CheckBox.dock Dock.Top
                     CheckBox.content "Is Horizontal"
                     CheckBox.onClick (fun _ -> dispatch FlipOrientation)

--- a/src/Avalonia.FuncUI.Diagnostics/Lib/Lib.ComponentAdorner.fs
+++ b/src/Avalonia.FuncUI.Diagnostics/Lib/Lib.ComponentAdorner.fs
@@ -6,7 +6,7 @@ open Avalonia.FuncUI
 open Avalonia.Media
 open Avalonia.Media.Immutable
 
-type internal ComponentHighlightAdorner (adornedElement: Component) as this =
+type internal ComponentHighlightAdorner (adornedElement: Component) =
     inherit Control ()
 
     override this.Render (ctx: DrawingContext) =

--- a/src/Avalonia.FuncUI.Diagnostics/Lib/Lib.Icons.fs
+++ b/src/Avalonia.FuncUI.Diagnostics/Lib/Lib.Icons.fs
@@ -10,7 +10,7 @@ open Avalonia.Media
 type IconView =
 
     static member create (drawing: Drawing, size: int) : IView =
-        Component.create ($"icon_{drawing.GetHashCode()}", fun ctx ->
+        Component.create ($"icon_{drawing.GetHashCode()}", fun _ctx ->
             let vectorImage = DrawingImage(drawing)
 
             Image.create [

--- a/src/Avalonia.FuncUI.Diagnostics/Views/Views.InspectorViews.fs
+++ b/src/Avalonia.FuncUI.Diagnostics/Views/Views.InspectorViews.fs
@@ -4,7 +4,6 @@ open Avalonia.FuncUI
 open Avalonia.FuncUI.Diagnostics
 open System
 open Avalonia.Controls
-open Avalonia.FuncUI
 open Avalonia.FuncUI.DSL
 open Avalonia.FuncUI.Types
 open Avalonia.Layout

--- a/src/Avalonia.FuncUI.Diagnostics/Views/Views.StateHookViews.fs
+++ b/src/Avalonia.FuncUI.Diagnostics/Views/Views.StateHookViews.fs
@@ -2,10 +2,8 @@ namespace Avalonia.FuncUI.Diagnostics
 
 open Avalonia.FuncUI
 open Avalonia.FuncUI.Diagnostics
-open System
 open Avalonia
 open Avalonia.Controls
-open Avalonia.FuncUI
 open Avalonia.FuncUI.DSL
 open Avalonia.FuncUI.Types
 open Avalonia.Layout

--- a/src/Avalonia.FuncUI.Diagnostics/Views/Views.StateHookViews.fs
+++ b/src/Avalonia.FuncUI.Diagnostics/Views/Views.StateHookViews.fs
@@ -78,7 +78,7 @@ type internal StateHookViews =
         )
 
     static member private stateHookSourcesView (hook: StateHook) =
-        Component.create ("state_hook_sources", fun ctx ->
+        Component.create ("state_hook_sources", fun _ctx ->
             TreeView.create [
                 TreeView.itemTemplate (
                     DataTemplateView<_>.create (
@@ -155,7 +155,7 @@ type internal StateHookViews =
         )
 
     static member stateHookDetailsView (hook: StateHook) =
-        Component.create ($"state_hook_detail_view_{hook.Identity}", fun ctx ->
+        Component.create ($"state_hook_detail_view_{hook.Identity}", fun _ctx ->
             StackPanel.create [
                 StackPanel.spacing 10.0
                 StackPanel.children [
@@ -182,7 +182,7 @@ type internal StateHookViews =
         )
 
     static member stateHookView (hook: StateHook) =
-        Component.create ($"state_hook_detail_view_{hook.Identity}", fun ctx ->
+        Component.create ($"state_hook_detail_view_{hook.Identity}", fun _ctx ->
             Border.create [
                 Border.padding 5.0
                 Border.child (

--- a/src/Avalonia.FuncUI.Elmish/Library.fs
+++ b/src/Avalonia.FuncUI.Elmish/Library.fs
@@ -19,10 +19,10 @@ module Program =
         let stateRef = ref None
         let setState state dispatch =
             // create new view and update the host only if new model is not equal to a prev one
-            let stateDiffers = (Some state).Equals(!stateRef) |> not
+            let stateDiffers = (Some state).Equals(stateRef.Value) |> not
             
             if stateDiffers then
-                stateRef := Some state
+                stateRef.Value <- Some state
                 let view = ((Program.view program) state dispatch)
                 host.Update (Some (view :> IView))
 

--- a/src/Avalonia.FuncUI/Components/Context/Context.fs
+++ b/src/Avalonia.FuncUI/Components/Context/Context.fs
@@ -66,6 +66,7 @@ type IComponentContext =
     /// </example>
     /// </summary>
     /// <param name="value">value should not change during the component lifetime.</param>
+    /// <param name="renderOnChange">re-render component on change (default: true).</param>
     abstract usePassed<'value> : value: IWritable<'value> * ?renderOnChange: bool -> IWritable<'value>
 
     /// <summary>

--- a/src/Avalonia.FuncUI/Components/State/State.Functions.fs
+++ b/src/Avalonia.FuncUI/Components/State/State.Functions.fs
@@ -2,7 +2,6 @@ namespace Avalonia.FuncUI
 
 open System
 open Avalonia.FuncUI
-open Microsoft.FSharp.Quotations
 
 [<RequireQualifiedAccess>]
 module State =

--- a/src/Avalonia.FuncUI/Components/State/State.fs
+++ b/src/Avalonia.FuncUI/Components/State/State.fs
@@ -101,7 +101,7 @@ type ReadOnlyState<'value>(init: 'value) =
         member this.Subscribe (_handler: 'value -> unit) =
             (* This is a constant value and therefore does never change. *)
             null
-        member this.SubscribeAny (handler: obj -> unit) : IDisposable =
+        member this.SubscribeAny (_handler: obj -> unit) : IDisposable =
             (* This is a constant value and therefore does never change. *)
             null
         member this.Dispose () =

--- a/src/Avalonia.FuncUI/DSL/Base/Control.fs
+++ b/src/Avalonia.FuncUI/DSL/Base/Control.fs
@@ -1,7 +1,5 @@
 namespace Avalonia.FuncUI.DSL
 
-open Avalonia.FuncUI.VirtualDom
-
 [<AutoOpen>]
 module Control =
     open Avalonia.Controls

--- a/src/Avalonia.FuncUI/DSL/Button.fs
+++ b/src/Avalonia.FuncUI/DSL/Button.fs
@@ -1,7 +1,5 @@
 namespace Avalonia.FuncUI.DSL
 
-open Avalonia
-
 [<AutoOpen>]
 module Button =
     open System.Windows.Input

--- a/src/Avalonia.FuncUI/DSL/DatePicker.fs
+++ b/src/Avalonia.FuncUI/DSL/DatePicker.fs
@@ -4,7 +4,6 @@
 module DatePicker =
     open System
     open Avalonia.Controls
-    open Avalonia.Controls.Templates
     open Avalonia.FuncUI.Types
     open Avalonia.FuncUI.Builder
     

--- a/src/Avalonia.FuncUI/DSL/Panels/Grid.fs
+++ b/src/Avalonia.FuncUI/DSL/Panels/Grid.fs
@@ -45,7 +45,7 @@ module Grid =
                             a.MaxHeight = b.MaxHeight &&
                             a.SharedSizeGroup = b.SharedSizeGroup
 
-                        member this.GetHashCode (a) =
+                        member this.GetHashCode a =
                             (a.Height, a.MinHeight, a.MaxHeight, a.SharedSizeGroup).GetHashCode()
                 }
             

--- a/src/Avalonia.FuncUI/DSL/Primitives/SelectingItemsControl.fs
+++ b/src/Avalonia.FuncUI/DSL/Primitives/SelectingItemsControl.fs
@@ -1,7 +1,5 @@
 namespace Avalonia.FuncUI.DSL
 
-open System.Collections
-
 [<AutoOpen>]
 module SelectingItemsControl =
     open Avalonia.Controls.Primitives

--- a/src/Avalonia.FuncUI/DSL/TextBox.fs
+++ b/src/Avalonia.FuncUI/DSL/TextBox.fs
@@ -1,7 +1,5 @@
 namespace Avalonia.FuncUI.DSL
 
-open Avalonia
-
 [<AutoOpen>]
 module TextBox =
     open Avalonia.Controls

--- a/src/Avalonia.FuncUI/DSL/TimePicker.fs
+++ b/src/Avalonia.FuncUI/DSL/TimePicker.fs
@@ -4,7 +4,6 @@
 module TimePicker =
     open System
     open Avalonia.Controls
-    open Avalonia.Controls.Templates
     open Avalonia.FuncUI.Types
     open Avalonia.FuncUI.Builder
     

--- a/src/Avalonia.FuncUI/DSL/TransitioningContentControl.fs
+++ b/src/Avalonia.FuncUI/DSL/TransitioningContentControl.fs
@@ -7,8 +7,6 @@ module TransitioningContentControl =
     open Avalonia.Controls
     open Avalonia.FuncUI.Types
     open Avalonia.FuncUI.Builder
-    open Avalonia.Controls.Templates
-    open Avalonia.Layout
 
     let create (attrs : IAttr<TransitioningContentControl> list) : IView<TransitioningContentControl> =
         ViewBuilder.Create<TransitioningContentControl>(attrs)

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Delta.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Delta.fs
@@ -119,3 +119,6 @@ module internal rec Delta =
                 this.KeyDidChange = other.KeyDidChange &&
                 (ValueOption.isSome this.Outlet = ValueOption.isSome other.Outlet)
             | _ -> false
+            
+        override this.GetHashCode() =
+            HashCode.Combine(this.ViewType, this.Attrs, this.ConstructorArgs, this.KeyDidChange, ValueOption.isSome this.Outlet)

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Delta.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Delta.fs
@@ -101,7 +101,7 @@ module internal rec Delta =
           Attrs: AttrDelta list
           ConstructorArgs: obj array
           KeyDidChange: bool
-          Outlet: (Avalonia.IAvaloniaObject -> unit) voption }
+          Outlet: (IAvaloniaObject -> unit) voption }
 
         static member From (view: IView, ?keyDidChange: bool) : ViewDelta =
             { ViewType = view.ViewType

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Patcher.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Patcher.fs
@@ -5,7 +5,6 @@ module internal rec Patcher =
     open System.Collections
     open System.Collections.Concurrent
     open Avalonia.Controls
-    open Avalonia.Controls.Documents
     open Avalonia
     open Avalonia.FuncUI.VirtualDom.Delta
     open Avalonia.FuncUI.Library


### PR DESCRIPTION
- Removed unused namespace imports
- Prefixed unused parameters with an underscore
- Match all possible `Orientation` values
- Override the `GetHashCode` method of the `ViewDelta` type

The `Avalonia.FuncUI.Diagnostics.Reflector` type mentions a `Maecos.Shared.NonEmptyList` type (note a possible type in "Maecos") — https://github.com/fsprojects/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.Diagnostics/Lib/Lib.Reflector.fs#L46. Is it a correct string or a different type was meant there?