### PR TITLE
Strictify Elmish dependency version

### DIFF
--- a/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
+++ b/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elmish" Version="3.1.0" />
+    <PackageReference Include="Elmish" Version="[3.1.0,4.0)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Elmish 4.0 introduced breaking changes, therefore Avalonia.FuncUI.Elmish doesn't work with that version (see #240). To avoid a non-working package resolution, I strictified the version requirement.

After that the generated .nupkg had the following dependencies:
```
Dependencies:
  net6.0:
    JaggerJo.Avalonia.FuncUI: '>= 0.6.04'
    Elmish: '>= 3.1.0 && < 4.0.0'
    FSharp.Core: '>= 7.0.0'
```