### PR TITLE
Update the style references in the Examples.Presso project

### DIFF
--- a/src/Examples/Component Examples/Examples.Presso/Styles/Styles.xaml
+++ b/src/Examples/Component Examples/Examples.Presso/Styles/Styles.xaml
@@ -2,8 +2,8 @@
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <StyleInclude Source="avares://Examples.Elmish.Presso/Styles/RadioButton.xaml"/>
-    <StyleInclude Source="avares://Examples.Elmish.Presso/Styles/Button.xaml"/>
+    <StyleInclude Source="avares://Examples.Presso/Styles/RadioButton.xaml"/>
+    <StyleInclude Source="avares://Examples.Presso/Styles/Button.xaml"/>
 
     <Style Selector="RadioButton.water">
         <Setter Property="Background" Value="#113248"/>


### PR DESCRIPTION
I was getting a build error about this with the latest Avalonia 11, but it appears that there is already a runtime error with the current code (were the xaml files copied from Example.Elmish.Presso without changing the namespaces?)