### PR TITLE
Add a package description field to the FuncUI project

### DIFF
--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -12,6 +12,7 @@
     <PackageIconUrl>https://github.com/FuncUI/Avalonia.FuncUI/blob/master/github/img/nuget_icon.png?raw=true</PackageIconUrl>
     <Title>Avalonia FuncUI</Title>
     <PackageVersion>$(FuncUIVersion)</PackageVersion>
+    <Description>Develop cross-plattform MVU GUI Applications using F# and Avalonia!</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Refs my comment in #222 about nuget.org currently showing the description as 'package description'...

Not sure what the text should be, so I just set it to the github about text to raise the question