### PR TITLE
Elmish hook optional overloads

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <AvaloniaVersion>11.0.0-preview4</AvaloniaVersion>
-    <FuncUIVersion>0.6.0-preview6.1</FuncUIVersion>
+    <FuncUIVersion>0.6.0-preview7</FuncUIVersion>
   </PropertyGroup>
 </Project>

--- a/src/Examples/Component Examples/Examples.ChordParser/ChordParserView.fs
+++ b/src/Examples/Component Examples/Examples.ChordParser/ChordParserView.fs
@@ -77,8 +77,8 @@ let private subscriptions (model: Model) : Sub<Msg> =
     ]
 
 let view () = Component (fun ctx ->
-    let model, dispatch = ctx.useElmish(init, update, (), Program.withSubscription subscriptions)
-    //let model, dispatch = ctx.useElmish(init, update, ()) // if no subscriptions are needed
+    let model, dispatch = ctx.useElmish(init, update, Program.withSubscription subscriptions)
+    //let model, dispatch = ctx.useElmish(init, update) // if no subscriptions are needed
     
     Grid.create [
         Grid.rowDefinitions "20, *"


### PR DESCRIPTION
Added an overload to `useElmish` hook that makes `initArg` does not need to be specified when `initArg` is `unit`. 

So this:
```F#
let model, dispatch = ctx.useElmish(init, update, ())
```

Can also be written as this:
```F#
let model, dispatch = ctx.useElmish(init, update)
```
