### PR TITLE
Switch the nuget packages from PackageIconUrl to PackageIcon

### DIFF
--- a/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
+++ b/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
@@ -9,14 +9,21 @@
     <PackageProjectUrl>https://github.com/FuncUI/Avalonia.FuncUI</PackageProjectUrl>
     <RepositoryUrl>https://github.com/FuncUI/Avalonia.FuncUI</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageIconUrl>https://github.com/FuncUI/Avalonia.FuncUI/blob/master/github/img/nuget_icon.png?raw=true</PackageIconUrl>
     <Title>Avalonia FuncUI Elmish</Title>
     <PackageVersion>$(FuncUIVersion)</PackageVersion>
+    <PackageIcon>nuget_icon.png</PackageIcon>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="ElmishHook.fs" />
     <Compile Include="Library.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\github\img\nuget_icon.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -9,10 +9,10 @@
     <PackageProjectUrl>https://github.com/FuncUI/Avalonia.FuncUI</PackageProjectUrl>
     <RepositoryUrl>https://github.com/FuncUI/Avalonia.FuncUI</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageIconUrl>https://github.com/FuncUI/Avalonia.FuncUI/blob/master/github/img/nuget_icon.png?raw=true</PackageIconUrl>
     <Title>Avalonia FuncUI</Title>
     <PackageVersion>$(FuncUIVersion)</PackageVersion>
     <Description>Develop cross-plattform MVU GUI Applications using F# and Avalonia!</Description>
+    <PackageIcon>nuget_icon.png</PackageIcon>
   </PropertyGroup>
 
   <ItemGroup>
@@ -137,6 +137,13 @@
     <Compile Include="DSL\TickBar.fs" />
     <Compile Include="DSL\Viewbox.fs" />
     <Compile Include="DSL\SelectableTextBlock.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\github\img\nuget_icon.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
There are a couple of build warnings about PackageIconUrl being deprecated - so, migrate the packages to PackageIcon