### PR TITLE
Add a PackageLicenseExpression to the projects

### DIFF
--- a/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
+++ b/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
@@ -6,6 +6,7 @@
     <Authors>JaggerJo</Authors>
     <Product>Avalonia.FuncUI.Elmish</Product>
     <PackageId>Avalonia.FuncUI.Elmish</PackageId>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/FuncUI/Avalonia.FuncUI</PackageProjectUrl>
     <RepositoryUrl>https://github.com/FuncUI/Avalonia.FuncUI</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -6,6 +6,7 @@
     <Authors>JaggerJo</Authors>
     <Product>Avalonia.FuncUI</Product>
     <PackageId>Avalonia.FuncUI</PackageId>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/FuncUI/Avalonia.FuncUI</PackageProjectUrl>
     <RepositoryUrl>https://github.com/FuncUI/Avalonia.FuncUI</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
I noticed whilst looking at other things that the nuget packages didn't seem to specify what their license is - perhaps they should?