### PR TITLE
Create a useStateLazy method which takes a callback

### DIFF
--- a/src/Avalonia.FuncUI/Components/Context/Context.fs
+++ b/src/Avalonia.FuncUI/Components/Context/Context.fs
@@ -57,7 +57,8 @@ type IComponentContext =
     /// <example>
     /// <code>
     /// Component (fun ctx ->
-    ///     let count = ctx.useStateLazy (fun () -> 42)
+    ///     (* expensive operation that should only happen once on initialisation *) 
+    ///     let count = ctx.useStateLazy (fun () -> Math.Sqrt(42))
     ///     ..
     ///     // id will have the same value during the whole component lifetime. (unless changed via 'id.Set ..')
     ///     let id = ctx.useState ((fun () -> Guid.NewGuid()), renderOnChange=false)


### PR DESCRIPTION
This means that if your default state is expensive to create, you don't need to create one (just to be discarded) every time the component is rendered.