### PR TITLE
Add a binding for ToggleButton.IsCheckedChangedEvent

### DIFF
--- a/src/Avalonia.FuncUI/DSL/Buttons/ToggleButton.fs
+++ b/src/Avalonia.FuncUI/DSL/Buttons/ToggleButton.fs
@@ -23,10 +23,9 @@ module ToggleButton =
             
         static member isChecked<'t when 't :> ToggleButton>(value: bool option) : IAttr<'t> =
             value |> Option.toNullable |> ToggleButton.isChecked
-            
-        [<Obsolete "use 'onChecked' or 'onUnchecked' instead">]
-        static member onIsCheckedChanged<'t when 't :> ToggleButton>(func: Nullable<bool> -> unit, ?subPatchOptions) : IAttr<'t> =
-            AttrBuilder<'t>.CreateSubscription<Nullable<bool>>(ToggleButton.IsCheckedProperty, func, ?subPatchOptions = subPatchOptions)
+        
+        static member onIsCheckedChanged<'t when 't :> ToggleButton>(func: RoutedEventArgs -> unit, ?subPatchOptions) : IAttr<'t> =
+            AttrBuilder<'t>.CreateSubscription<RoutedEventArgs>(ToggleButton.IsCheckedChangedEvent, func, ?subPatchOptions = subPatchOptions)
             
         static member onChecked<'t when 't :> ToggleButton>(func: RoutedEventArgs -> unit, ?subPatchOptions) : IAttr<'t> =
             AttrBuilder<'t>.CreateSubscription<RoutedEventArgs>(ToggleButton.CheckedEvent, func, ?subPatchOptions = subPatchOptions)


### PR DESCRIPTION
refs this deprecation in Avalonia 11:

![image](https://user-images.githubusercontent.com/1178570/225433637-9413319f-28f3-43b9-b8d1-441ebab09535.png)

where ```IsCheckedChangedEvent``` is a new one.

This is perhaps a tad confusing in the bindings, where there is already an ```onIsCheckedChanged``` bound to ```IsCheckedProperty``` which is itself marked as obsolete, so not sure what the desired approach is there.