### PR TITLE
New properties in Avalonia supporting touch scrolling

### DIFF
--- a/src/Avalonia.FuncUI/DSL/ItemsControl.fs
+++ b/src/Avalonia.FuncUI/DSL/ItemsControl.fs
@@ -25,5 +25,11 @@ module ItemsControl =
         static member itemTemplate<'t when 't :> ItemsControl>(value: IDataTemplate) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<IDataTemplate>(ItemsControl.ItemTemplateProperty, value, ValueNone)
 
+        static member areHorizontalSnapPointsRegular<'t when 't :> ItemsControl>(value: bool) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<bool>(ItemsControl.AreHorizontalSnapPointsRegularProperty, value, ValueNone)
+
+        static member areVerticalSnapPointsRegular<'t when 't :> ItemsControl>(value: bool) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<bool>(ItemsControl.AreVerticalSnapPointsRegularProperty, value, ValueNone)
+
         static member onItemsChanged<'t when 't :> ItemsControl>(func: IList -> unit, ?subPatchOptions) =
             AttrBuilder<'t>.CreateSubscription<IList, _>(ItemsControl.ItemsProperty, func, ?subPatchOptions = subPatchOptions)


### PR DESCRIPTION
A couple of new properties on ItemsControl related to scrolling (for touch UI, but the size calculations they affect are performed for all UI). 