### PR TITLE
[wip] Start updating to Avalonia 11 preview 7

### DIFF
--- a/src/Avalonia.FuncUI.Diagnostics/Views/Views.StateHookViews.fs
+++ b/src/Avalonia.FuncUI.Diagnostics/Views/Views.StateHookViews.fs
@@ -24,12 +24,12 @@ type internal StateHookViews =
                         ContextMenu.viewItems [
                             MenuItem.create [
                                 MenuItem.header "Copy"
-                                MenuItem.onClick (fun _ ->
+                                MenuItem.onClick (fun args ->
                                     Async.StartImmediate (
                                         async {
                                             let json = System.Text.Json.JsonSerializer.Serialize value.Current
 
-                                            do! Async.AwaitTask (Application.Current.Clipboard.SetTextAsync json)
+                                            do! Async.AwaitTask (TopLevel.GetTopLevel(args.Source :?> Visual).Clipboard.SetTextAsync json)
                                         }
                                     )
                                 )

--- a/src/Avalonia.FuncUI.UnitTests/VirtualDom/VirtualDom.PatcherTests.fs
+++ b/src/Avalonia.FuncUI.UnitTests/VirtualDom/VirtualDom.PatcherTests.fs
@@ -53,8 +53,11 @@ module PatcherTests =
                 se.Styles.AddRange(s))
 
         let classesGetter: AvaloniaObject -> obj = (fun c -> (c :?> StyledElement).Classes :> obj)
-        let classesSetter: AvaloniaObject * obj -> unit = (fun (c, v) -> (c :?> StyledElement).Classes <- v :?> Classes)
-
+        let classesSetter: AvaloniaObject * obj -> unit = (fun (c, v) -> 
+            let element = (c :?> StyledElement)
+            element.Classes.Clear()
+            element.Classes.AddRange(v :?> Classes))
+      
         let resourcesGetter: AvaloniaObject -> obj = (fun c -> (c :?> StyledElement).Resources :> obj)
         let resourcesSetter: AvaloniaObject * obj -> unit = (fun (c, v) -> (c :?> StyledElement).Resources <- v :?> IResourceDictionary)
 
@@ -97,7 +100,7 @@ module PatcherTests =
 
         let control = TextBlock()
         control.Styles.Add(Style())
-        control.Classes <- Classes([| "class" |])
+        control.Classes.Add("class")
         control.Resources.Add(KeyValuePair.Create("key" :> obj, "Value" :> obj))
 
         Patcher.patch (control, delta)

--- a/src/Avalonia.FuncUI/DSL/AutoCompleteBox.fs
+++ b/src/Avalonia.FuncUI/DSL/AutoCompleteBox.fs
@@ -73,7 +73,7 @@ module AutoCompleteBox =
             AttrBuilder<'t>.CreateProperty<_>(AutoCompleteBox.TextFilterProperty, filterFunc, ValueNone)
 
         static member dataItems<'t when 't :> AutoCompleteBox>(items: IEnumerable) : IAttr<'t> =
-            AttrBuilder<'t>.CreateProperty<IEnumerable>(AutoCompleteBox.ItemsProperty, items, ValueNone)
+            AttrBuilder<'t>.CreateProperty<IEnumerable>(AutoCompleteBox.ItemsSourceProperty, items, ValueNone)
 
         static member asyncPopulator<'t when 't :> AutoCompleteBox>(populator: Func<string, CancellationToken, Task<seq<obj>>>) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<_>(AutoCompleteBox.AsyncPopulatorProperty, populator, ValueNone)

--- a/src/Avalonia.FuncUI/DSL/Base/StyledElement.fs
+++ b/src/Avalonia.FuncUI/DSL/Base/StyledElement.fs
@@ -24,7 +24,9 @@ module StyledElement =
 
         static member classes<'t when 't :> StyledElement>(value: Classes) : IAttr<'t> =
             let getter : ('t -> Classes) = (fun control -> control.Classes)
-            let setter : ('t * Classes -> unit) = (fun (control, value) -> control.Classes <- value)
+            let setter : ('t * Classes -> unit) = (fun (control, value) ->              
+                control.Classes.Clear()
+                control.Classes.AddRange(value))
             
             AttrBuilder<'t>.CreateProperty<Classes>("Classes", value, ValueSome getter, ValueSome setter, ValueNone, fun () -> Classes())
             

--- a/src/Avalonia.FuncUI/DSL/DataGrid.fs
+++ b/src/Avalonia.FuncUI/DSL/DataGrid.fs
@@ -26,7 +26,7 @@ module DataGrid =
             AttrBuilder<'t>.CreateProperty<bool>(DataGrid.AutoGenerateColumnsProperty, autoGenerate, ValueNone)
 
         static member items (items: #System.Collections.IEnumerable) : IAttr<DataGrid> =
-            AttrBuilder<DataGrid>.CreateProperty(DataGrid.ItemsProperty, items, ValueNone)
+            AttrBuilder<DataGrid>.CreateProperty(DataGrid.ItemsSourceProperty, items, ValueNone)
 
         static member canUserReorderColumns<'t when 't :> DataGrid>(value: bool) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<bool>(DataGrid.CanUserReorderColumnsProperty, value, ValueNone)

--- a/src/Avalonia.FuncUI/DSL/Flyout.fs
+++ b/src/Avalonia.FuncUI/DSL/Flyout.fs
@@ -60,10 +60,12 @@ module MenuFlyout =
     type MenuFlyout with
 
         static member viewItems<'t when 't :> MenuFlyout>(views: List<IView>): IAttr<'t> =
-            AttrBuilder<'t>.CreateContentMultiple(MenuFlyout.ItemsProperty, views)
+            let getter : ('t -> obj) = (fun control -> control.Items :> obj)
+
+            AttrBuilder<'t>.CreateContentMultiple("Items", ValueSome getter, ValueNone, views)
 
         static member dataItems<'t when 't :> MenuFlyout>(data : IEnumerable): IAttr<'t> =
-            AttrBuilder<'t>.CreateProperty<IEnumerable>(MenuFlyout.ItemsProperty, data, ValueNone)
+            AttrBuilder<'t>.CreateProperty<IEnumerable>(MenuFlyout.ItemsSourceProperty, data, ValueNone)
 
         static member itemTemplate<'t when 't :> MenuFlyout>(value : IDataTemplate): IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<IDataTemplate>(MenuFlyout.ItemTemplateProperty, value, ValueNone)

--- a/src/Avalonia.FuncUI/DSL/ItemsControl.fs
+++ b/src/Avalonia.FuncUI/DSL/ItemsControl.fs
@@ -14,7 +14,8 @@ module ItemsControl =
     type ItemsControl with
 
         static member viewItems<'t when 't :> ItemsControl>(views: IView list) : IAttr<'t> =
-            AttrBuilder<'t>.CreateContentMultiple(ItemsControl.ItemsProperty, views)
+            let getter : ('t -> obj) = (fun control -> control.Items :> obj)
+            AttrBuilder<'t>.CreateContentMultiple("Items", ValueSome getter, ValueNone, views)
 
         static member dataItems<'t when 't :> ItemsControl>(data: IEnumerable) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<IEnumerable>(ItemsControl.ItemsSourceProperty, data, ValueNone)

--- a/src/Avalonia.FuncUI/DSL/ScrollViewer.fs
+++ b/src/Avalonia.FuncUI/DSL/ScrollViewer.fs
@@ -63,11 +63,11 @@ module ScrollViewer  =
         /// <summary>
         /// Sets the vertical scrollbar value.
         /// </summary>
-        static member verticalScrollBarValue<'t when 't :> ScrollViewer>(value: double) : IAttr<'t> =
-            AttrBuilder<'t>.CreateProperty<double>(ScrollViewer.VerticalScrollBarValueProperty, value, ValueNone)
+        //static member verticalScrollBarValue<'t when 't :> ScrollViewer>(value: double) : IAttr<'t> =
+        //    AttrBuilder<'t>.CreateProperty<double>(ScrollViewer.ver, value, ValueNone)
             
          /// <summary>
         /// Sets the horizontal scrollbar value.
         /// </summary>
-        static member horizontalScrollBarValue<'t when 't :> ScrollViewer>(value: double) : IAttr<'t> =
-            AttrBuilder<'t>.CreateProperty<double>(ScrollViewer.HorizontalScrollBarValueProperty, value, ValueNone)
+        //static member horizontalScrollBarValue<'t when 't :> ScrollViewer>(value: double) : IAttr<'t> =
+        //    AttrBuilder<'t>.CreateProperty<double>(ScrollViewer.HorizontalScrollBarValueProperty, value, ValueNone)

--- a/src/Avalonia.FuncUI/DSL/ViewBuilder.fs
+++ b/src/Avalonia.FuncUI/DSL/ViewBuilder.fs
@@ -6,7 +6,6 @@ open Avalonia.FuncUI.Types
 [<AbstractClass; Sealed>]
 type ViewBuilder() =
 
-    [<System.Obsolete "Use 'View.createGeneric' instead.">]
     static member Create<[<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)>]'view>(attrs: IAttr<'view> list) : IView<'view> =
         { View.ViewType = typeof<'view>
           View.ViewKey = ValueNone

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <AvaloniaVersion>11.0.0-preview6</AvaloniaVersion>
+    <AvaloniaVersion>11.0.0-preview7</AvaloniaVersion>
     <FuncUIVersion>0.6.0-preview9.1</FuncUIVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
A start on getting things working with preview 7.

main changes:

-The classes property is now read only
-Various controls have been changed to use ItemsSource instead of Items
-The Items property on ItemsControl has been made a regular instance property, which is read only

I tried changing ItemsControl.viewitems but haven't changed onItemsChanged and there is also a change needed to clipboard access in the diagnostics lib