### PR TITLE
Replace uses of the deprecated IStyleable with StyleKeyOverride

### DIFF
--- a/src/Avalonia.FuncUI/Components/Component.fs
+++ b/src/Avalonia.FuncUI/Components/Component.fs
@@ -4,7 +4,6 @@ open System
 open Avalonia.Controls
 open Avalonia.FuncUI
 open Avalonia.FuncUI.Types
-open Avalonia.Styling
 open Avalonia.FuncUI.VirtualDom
 open Avalonia.Threading
 
@@ -63,8 +62,7 @@ type Component (render: IComponentContext -> IView) as this =
         base.Finalize ()
         (context :> IDisposable).Dispose ()
 
-    interface IStyleable with
-        member this.StyleKey = typeof<Border>
+    override this.StyleKeyOverride = typeof<Border>
 
 type Component with
 

--- a/src/Avalonia.FuncUI/Components/StaticComponent.fs
+++ b/src/Avalonia.FuncUI/Components/StaticComponent.fs
@@ -3,7 +3,6 @@ namespace Avalonia.FuncUI
 open Avalonia
 open Avalonia.Controls
 open Avalonia.FuncUI.Types
-open Avalonia.Styling
 
 [<AbstractClass>]
 [<Experimental "Statically construct views with F#">]
@@ -21,5 +20,4 @@ type StaticComponent () =
 
     abstract member Build: unit -> IView
 
-    interface IStyleable with
-        member this.StyleKey = typeof<Border>
+    override this.StyleKeyOverride = typeof<Border>

--- a/src/Avalonia.FuncUI/Environment.fs
+++ b/src/Avalonia.FuncUI/Environment.fs
@@ -31,8 +31,7 @@ type EnvironmentStateProvider<'value>
 
     member this.ProvidedState with get () = providedState
 
-    interface IStyleable with
-        member this.StyleKey = typeof<ContentControl>
+    override this.StyleKeyOverride = typeof<ContentControl>
 
 type EnvironmentStateProvider<'value> with
 

--- a/src/Avalonia.FuncUI/Hosts.fs
+++ b/src/Avalonia.FuncUI/Hosts.fs
@@ -30,8 +30,7 @@ type HostControl() as this =
         VirtualDom.updateRoot (this, lastViewElement, nextViewElement)
         lastViewElement <- nextViewElement
 
-    interface IStyleable with
-        member this.StyleKey = typeof<ContentControl>
+    override this.StyleKeyOverride = typeof<ContentControl>
 
     interface IViewHost with
         member this.Update next =


### PR DESCRIPTION
An attempt at fixing the deprection warnings in Avalonia 11 RC1, as described at https://github.com/AvaloniaUI/Avalonia/wiki/Avalonia-11-Porting-Guide#optional-but-recommended