### PR TITLE
Perf optimization on diffContentMultiple

### DIFF
--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Differ.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Differ.fs
@@ -65,12 +65,12 @@ module internal rec Differ =
 
     let private diffContentMultiple (lastList: IView list, nextList: IView list) : ViewDelta list =
         let lastList = lastList |> List.toArray
-        nextList
-        |> List.mapi (fun index next ->
-            if index < lastList.Length
-            then Differ.diff (lastList.[index], next)
-            else ViewDelta.From next
-            )
+        nextList |> List.mapi (fun index next ->
+            if index < lastList.Length then
+                Differ.diff(lastList.[index], next)
+            else
+                ViewDelta.From next
+        )
 
     let private diffContent (last: IAttr, next: IAttr) : ViewContentDelta =
             match next with

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Differ.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Differ.fs
@@ -64,12 +64,13 @@ module internal rec Differ =
         | None -> None
 
     let private diffContentMultiple (lastList: IView list, nextList: IView list) : ViewDelta list =
-        nextList |> List.mapi (fun index next ->
-            if index + 1 <= lastList.Length then
-                Differ.diff(lastList.[index], nextList.[index])
-            else
-                ViewDelta.From next
-        )
+        let lastList = lastList |> List.toArray
+        nextList
+        |> List.mapi (fun index next ->
+            if index < lastList.Length
+            then Differ.diff (lastList.[index], next)
+            else ViewDelta.From next
+            )
 
     let private diffContent (last: IAttr, next: IAttr) : ViewContentDelta =
             match next with

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Differ.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Differ.fs
@@ -64,10 +64,15 @@ module internal rec Differ =
         | None -> None
 
     let private diffContentMultiple (lastList: IView list, nextList: IView list) : ViewDelta list =
-        let lastList = lastList |> List.toArray
+        let lastListLength = lastList.Length
+
+        let mutable lastTail: IView list = lastList
+
         nextList |> List.mapi (fun index next ->
-            if index < lastList.Length then
-                Differ.diff(lastList.[index], next)
+            if index + 1 <= lastListLength then
+                let result = diff(lastTail.Head, next)
+                lastTail <- lastTail.Tail
+                result
             else
                 ViewDelta.From next
         )


### PR DESCRIPTION
Convert lastList to array to speed up indexed access for large lists.