### PR TITLE
Fix example titles

### DIFF
--- a/src/Examples/Component Examples/Examples.EnvApp/Program.fs
+++ b/src/Examples/Component Examples/Examples.EnvApp/Program.fs
@@ -202,7 +202,7 @@ type Views =
 type MainWindow() as this =
     inherit HostWindow()
     do
-        base.Title <- "Drawing App"
+        base.Title <- "Environment App"
         base.Width <- 500.0
         base.Height <- 500.0
         this.Content <- Views.main ()

--- a/src/Examples/Examples.DataGridPlayground/Program.fs
+++ b/src/Examples/Examples.DataGridPlayground/Program.fs
@@ -77,7 +77,7 @@ type Views =
 type MainWindow() as this =
     inherit HostWindow()
     do
-        base.Title <- "Drawing App"
+        base.Title <- "DataGrid Playground"
         base.Width <- 500.0
         base.Height <- 500.0
         this.Content <- Views.main ()


### PR DESCRIPTION
A couple of the example projects have the same window title as Examples.DrawingApp which can lead to confusion when looking at the examples. Maybe the titles can be even better but at least this fixes the ones that are incorrect.