### PR TITLE
Fix a few 'Pattern discard is not allowed for union case that takes n…

### DIFF
--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Patcher.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Patcher.fs
@@ -81,7 +81,7 @@ module internal rec Patcher =
 
             match instanceProperty.Setter with
             | ValueSome setter -> setter (view, value)
-            | ValueNone _ -> failwithf "instance property ('%s') has no setter. " instanceProperty.Name
+            | ValueNone -> failwithf "instance property ('%s') has no setter. " instanceProperty.Name
 
     let private patchContentMultiple (view: AvaloniaObject, accessor: Accessor, delta: ViewDelta list) : unit =
         (* often lists only have a get accessor *)

--- a/src/Examples/Component Examples/Examples.GeneticAlgorithm/Lib/Simulator.fs
+++ b/src/Examples/Component Examples/Examples.GeneticAlgorithm/Lib/Simulator.fs
@@ -8,9 +8,9 @@ module Simulator =
   let canEnterActorCell actor target =
     match target with
     | Rabbit | Squirrel _ -> actor = Doggo // Dog can eat the squirrel or rabbit
-    | Doggo _ -> false // Nobody bugs the dog
-    | Tree _ -> actor = Squirrel true // Only allow if squirrel has an acorn
-    | Acorn _ -> actor = Squirrel false // Only allow if squirrel w/o acorn
+    | Doggo -> false // Nobody bugs the dog
+    | Tree -> actor = Squirrel true // Only allow if squirrel has an acorn
+    | Acorn -> actor = Squirrel false // Only allow if squirrel w/o acorn
 
   let moveActor state actor pos =
     let world = state.World


### PR DESCRIPTION
…o data' warnings from the .NET 8 compiler

Pretty simple, but - there are several instances of
```
\src\Avalonia.FuncUI\VirtualDom\VirtualDom.Patcher.fs(84,15): warning FS3548: Pattern discard is not allowed for union case that takes no data.
```
when building with the .NET 8 SDK (a new diagnostic in the updated compiler I believe)