### PR TITLE
Replace a use of Seq.iteri over a list with List.iteri

### DIFF
--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Patcher.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.Patcher.fs
@@ -89,7 +89,7 @@ module internal rec Patcher =
             if List.isEmpty delta then
                 collection.Clear()
             else
-                delta |> Seq.iteri (fun index viewElement ->
+                delta |> List.iteri (fun index viewElement ->
                     // try patch / reuse
                     if index + 1 <= collection.Count then
                         let item = collection.[index]


### PR DESCRIPTION
I've been having a go with with the [F# analyzers](http://ionide.io/FSharp.Analyzers.SDK/) tools, and got this suggestion that using List.iteri rather than Seq.iteri when the collection is known to be a list should be more efficient

```
Avalonia.FuncUI\VirtualDom\VirtualDom.Patcher.fs(92,25): Warning GRA-VIRTUALCALL-001 - Consider replacing the call of Seq.iteri with a function from the List module to avoid the costs of virtual calls.
```
