### PR TITLE
Use 'dotnet workload restore' to restore workloads in the PR CI builds

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -22,11 +22,8 @@ jobs:
           6.x.x
           7.x.x
 
-    - name: install workload ios
-      run: dotnet workload install ios
-
-    - name: install workload wasm
-      run: dotnet workload install wasm-tools
+    - name: install workloads
+      run: dotnet workload restore src/Avalonia.FuncUI.sln
 
     - name: Restore dependencies
       run: dotnet restore src/Avalonia.FuncUI.sln


### PR DESCRIPTION
refs #380 and the build failure in #381