### PR TITLE
Add static property ClipboardContentBinding to DataGridBoundColumn

### DIFF
--- a/src/Avalonia.FuncUI/DSL/DataGrid.fs
+++ b/src/Avalonia.FuncUI/DSL/DataGrid.fs
@@ -90,6 +90,15 @@ module DataGridBoundColumn =
                 setter = ValueSome (fun (column, value) -> column.Binding <- value),
                 comparer = ValueNone
             )
+            
+        static member clipboardContentBinding<'t when 't :> DataGridBoundColumn>(binding: IBinding) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<IBinding>(
+                name = "ClipboardContentBinding",
+                value = binding,
+                getter = ValueSome (fun column -> column.ClipboardContentBinding),
+                setter = ValueSome (fun (column, value) -> column.ClipboardContentBinding <- value),
+                comparer = ValueNone
+            )
 
 
 [<AutoOpen>]


### PR DESCRIPTION
Context from the Avalonia docs: https://reference.avaloniaui.net/api/Avalonia.Controls/DataGridBoundColumn/21520FC9

One issue with DataGrid in FuncUI is that copying is only limited to the whole row. Setting this property should allow users to copy the cells they are selecting. 