### PR TITLE
Update unit testing libraries

### DIFF
--- a/src/Avalonia.FuncUI.UnitTests/Avalonia.FuncUI.UnitTests.fsproj
+++ b/src/Avalonia.FuncUI.UnitTests/Avalonia.FuncUI.UnitTests.fsproj
@@ -21,9 +21,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is pretty trivial, but - 

The NuGet vulnerability reporting feature in the latest Visual Studio reports a warning about a transient dependency in the unit tests project:
![image](https://github.com/fsprojects/Avalonia.FuncUI/assets/1178570/885f7709-3a7d-4035-b124-31e1e9ccb62d)

Updating the unit testing libs to the latest version trims out a huge amount of transitive dependencies on rather old versions of things, which sorts that but also makes the dependencies much cleaner:

![image](https://github.com/fsprojects/Avalonia.FuncUI/assets/1178570/819e6e24-3c10-4370-b0bd-6eb7d5181fb1)
