### PR TITLE
Update Github actions in the PR build pipeline

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -13,10 +13,10 @@ jobs:
     - name: xCode
       run: sudo xcode-select -s /Applications/Xcode_14.3.app/Contents/Developer/
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
 
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           6.x.x


### PR DESCRIPTION
I noticed this in the build results when looking at other things:

![image](https://github.com/fsprojects/Avalonia.FuncUI/assets/1178570/1a214723-90a3-400f-9c02-9aa0533fa6f7)

so lets try updating the actions