### PR TITLE
Add System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers  in a …

### DIFF
--- a/src/Avalonia.FuncUI/Types.fs
+++ b/src/Avalonia.FuncUI/Types.fs
@@ -1,12 +1,12 @@
-﻿namespace rec Avalonia.FuncUI
+﻿namespace Avalonia.FuncUI
 
 open Avalonia
 open Avalonia.Controls
 open System
 open System.Threading
-open Avalonia.Data
+open System.Diagnostics.CodeAnalysis
 
-module Types =
+module rec Types =
 
     [<CustomEquality; NoComparison; Struct>]
     type PropertyAccessor =
@@ -153,11 +153,11 @@ module Types =
         abstract member ConstructorArgs: obj array with get
         abstract member Outlet: (AvaloniaObject -> unit) voption with get
 
-    type IView<'viewType> =
+    type IView<[<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)>]'viewType> =
         inherit IView
         abstract member Attrs: IAttr<'viewType> list with get
 
-    type View<'viewType> =
+    type View<[<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)>]'viewType> =
         { ViewType: Type
           ViewKey: string voption
           Attrs: IAttr<'viewType> list

--- a/src/Examples/Component Examples/Examples.ContactBook/Examples.ContactBook.fsproj
+++ b/src/Examples/Component Examples/Examples.ContactBook/Examples.ContactBook.fsproj
@@ -26,6 +26,7 @@
 
     <ItemGroup>
       <PackageReference Include="Bogus" Version="34.0.1" />
+      <TrimmerRootAssembly Include="Bogus" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
…couple more places

refs #367 

This is some trial and error based on linker warnings and testing rather than a clear 'this was wrong', but on top of the current FuncUI it does appear to be sufficient to get my app running without problems in a NativeAOT build.

Note: For reasons I'm not quite clear on, the compiler wouldn't accept the attributes unless I fully qualified the names, *unless* I remove the ```rec``` from the namespace declaration and put it on the ```Types``` module instead - not sure what's going on there