### PR TITLE
Update the actions in the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           6.x.x


### PR DESCRIPTION
refs

![image](https://github.com/fsprojects/Avalonia.FuncUI/assets/1178570/072c9956-8d97-4fa8-893f-37fb86942a93)

Matches the versions that the PR workflow was changed to in #393 