### PR TITLE
Change the Elmish music player example to use IStorageProvider instea…

### DIFF
--- a/src/Examples/Elmish Examples/Examples.Elmish.MusicPlayer/Examples.Elmish.MusicPlayer.fsproj
+++ b/src/Examples/Elmish Examples/Examples.Elmish.MusicPlayer/Examples.Elmish.MusicPlayer.fsproj
@@ -32,7 +32,7 @@
         <PackageReference Include="VideoLAN.LibVLC.Mac" Version="3.1.3.1" />
         <ProjectReference Include="..\..\..\Avalonia.FuncUI.Elmish\Avalonia.FuncUI.Elmish.fsproj" />
         <ProjectReference Include="..\..\..\Avalonia.FuncUI\Avalonia.FuncUI.fsproj" />
-        <PackageReference Include="LibVLCSharp" Version="3.4.2" />
-        <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.8.1" />
+        <PackageReference Include="LibVLCSharp" Version="3.8.5" />
+        <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.20" />
     </ItemGroup>
 </Project>

--- a/src/Examples/Elmish Examples/Examples.Elmish.MusicPlayer/Shell.fs
+++ b/src/Examples/Elmish Examples/Examples.Elmish.MusicPlayer/Shell.fs
@@ -7,11 +7,13 @@ module Shell =
     open Avalonia.Controls
     open Avalonia.Input
     open Avalonia.Layout
+    open Avalonia.Platform.Storage
     open Avalonia.FuncUI.Elmish
     open Avalonia.FuncUI.Hosts
     open Avalonia.FuncUI.DSL
     open LibVLCSharp.Shared
     open Examples.MusicPlayer
+    open System.Collections.Generic
 
     type State =
         { title: string
@@ -24,8 +26,8 @@ module Shell =
         | SetTitle of string
         | OpenFiles
         | OpenFolder
-        | AfterSelectFolder of string
-        | AfterSelectFiles of string array
+        | AfterSelectFolder of IReadOnlyList<IStorageFolder>
+        | AfterSelectFiles of IReadOnlyList<IStorageFile>
         (* Handle Media Player Events *)
         | Playing
         | Paused
@@ -122,15 +124,13 @@ module Shell =
             window.Title <- title
             { state with title = title }, Cmd.none
         | OpenFiles ->
-            let dialog = Dialogs.getMusicFilesDialog None
-            let showDialog window = dialog.ShowAsync(window) |> Async.AwaitTask
-            state, Cmd.OfAsync.perform showDialog window AfterSelectFiles
+            let showDialog storageProvider = Dialogs.showMusicFilesDialog (storageProvider, None)
+            state, Cmd.OfAsync.perform showDialog window.StorageProvider AfterSelectFiles
         | OpenFolder ->
-            let dialog = Dialogs.getFolderDialog
-            let showDialog window = dialog.ShowAsync(window) |> Async.AwaitTask
-            state, Cmd.OfAsync.perform showDialog window AfterSelectFolder
-        | AfterSelectFolder path ->
-            let songs = Songs.populateFromDirectory path |> Array.toList
+            let showDialog storageProvider = Dialogs.showMusicFolderDialog storageProvider
+            state, Cmd.OfAsync.perform showDialog window.StorageProvider AfterSelectFolder
+        | AfterSelectFolder paths ->
+            let songs = Songs.populateFromFolders paths |> Array.toList
             state, Cmd.map PlaylistMsg (Cmd.ofMsg (Playlist.Msg.AddFiles songs))
         | AfterSelectFiles paths ->
             let songs = Songs.populateSongs paths |> Array.toList

--- a/src/Examples/Elmish Examples/Examples.Elmish.MusicPlayer/Shell.fs
+++ b/src/Examples/Elmish Examples/Examples.Elmish.MusicPlayer/Shell.fs
@@ -185,8 +185,10 @@ module Shell =
     type ShellWindow() as this =
         inherit HostWindow()
         do
+            let iconPath = System.IO.Path.Combine("Assets", "Icons", "icon.ico")
+
             base.Title <- "Music Player in F# :)"
-            base.Icon <- WindowIcon("Assets\Icons\icon.ico")
+            base.Icon <- WindowIcon(iconPath)
             base.Width <- 800.0
             base.Height <- 600.0
             base.MinWidth <- 526.0

--- a/src/Examples/Elmish Examples/Examples.Elmish.MusicPlayer/Songs.fs
+++ b/src/Examples/Elmish Examples/Examples.Elmish.MusicPlayer/Songs.fs
@@ -1,20 +1,19 @@
 namespace Examples.MusicPlayer
 
-
 module Songs =
     open System
     open System.IO
     open Types
+    open Avalonia.Platform.Storage
 
-    let populateSongs (paths: string array): Types.SongRecord array =
+    let populateSongs (paths: IStorageFile seq): Types.SongRecord array =
         paths
-        |> Array.Parallel.map FileInfo
-        |> Array.Parallel.map (fun info -> info.Name, info.FullName)
-        |> Array.Parallel.map (fun (name, path) ->
+        |> Seq.map (fun storageFile ->
             { id = Guid.NewGuid()
-              name = name
-              path = path
+              name = storageFile.Name
+              path = storageFile.Path.LocalPath
               createdAt = DateTime.Now })
+        |> Array.ofSeq
 
     let populateFromDirectory (path: string): Types.SongRecord array =
         match String.IsNullOrEmpty path with
@@ -29,3 +28,9 @@ module Songs =
                   name = name
                   path = path
                   createdAt = DateTime.Now })
+
+    let populateFromFolders(folders: IStorageFolder seq) =
+        folders
+        |> Seq.map _.Path.LocalPath
+        |> Seq.map populateFromDirectory
+        |> Array.concat


### PR DESCRIPTION
…d of the obsoleted OpenFileDialog/OpenFolderDialog

As it stands, there are a bunch of build warnings about using the deprecated file / folder picker APIs, and this is an attempt to sort those by changing it to use the newer IStorageProvider interfaces.

Notes:
1) Only changes the picker access, the files/folder are still stored as string file paths
2) IStorageFolder has functions for listing items in the folder, but they're async, so I left ```populateFromDirectory``` mapping back into paths to avoid further changes for now.
