### PR TITLE
Remove the hard coded path separators for the music player sample icon

### DIFF
--- a/src/Examples/Elmish Examples/Examples.Elmish.MusicPlayer/Shell.fs
+++ b/src/Examples/Elmish Examples/Examples.Elmish.MusicPlayer/Shell.fs
@@ -185,8 +185,10 @@ module Shell =
     type ShellWindow() as this =
         inherit HostWindow()
         do
+            let iconPath = System.IO.Path.Combine("Assets", "Icons", "icon.ico")
+
             base.Title <- "Music Player in F# :)"
-            base.Icon <- WindowIcon("Assets\Icons\icon.ico")
+            base.Icon <- WindowIcon(iconPath)
             base.Width <- 800.0
             base.Height <- 600.0
             base.MinWidth <- 526.0


### PR DESCRIPTION
If I try to run the current version on macOS or Ubuntu it blows up trying to load the icon file, and this seems to sort it