### PR TITLE
Remove isPressed property setter

### DIFF
--- a/src/Avalonia.FuncUI/DSL/Buttons/Button.fs
+++ b/src/Avalonia.FuncUI/DSL/Buttons/Button.fs
@@ -29,9 +29,6 @@ module Button =
         static member isDefault<'t when 't :> Button>(value: bool) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<bool>(Button.IsDefaultProperty, value, ValueNone)
 
-        static member isPressed<'t when 't :> Button>(value: bool) : IAttr<'t> =
-            AttrBuilder<'t>.CreateProperty<bool>(Button.IsPressedProperty, value, ValueNone)
-
         static member onIsPressedChanged<'t when 't :> Button>(func: bool -> unit, ?subPatchOptions) =
             AttrBuilder<'t>.CreateSubscription<bool>(Button.IsPressedProperty, func, ?subPatchOptions = subPatchOptions)
 


### PR DESCRIPTION
Opening an old project I had, I noticed that it was breaking because of the `isPressed` not being public. Went onto check on the repo and upon adding `Button.isPressed true` to the counter example, it breaks as well:

```
Unhandled exception. System.ArgumentException: The property IsPressed is readonly.
   at Avalonia.DirectProperty`2.InvokeSetter(AvaloniaObject instance, BindingValue`1 value) in /_/src/Avalonia.Base/DirectProperty.cs:line 120
   at Avalonia.AvaloniaObject.SetDirectValueUnchecked[T](DirectPropertyBase`1 property, T value) in /_/src/Avalonia.Base/AvaloniaObject.cs:line 749
   at Avalonia.AvaloniaObject.SetValue[T](DirectPropertyBase`1 property, T value) in /_/src/Avalonia.Base/AvaloniaObject.cs:line 355
   at Avalonia.DirectPropertyBase`1.RouteSetValue(AvaloniaObject o, Object value, BindingPriority priority) in /_/src/Avalonia.Base/DirectPropertyBase.cs:line 146
   at Avalonia.AvaloniaObject.SetValue(AvaloniaProperty property, Object value, BindingPriority priority) in
...
   at Examples.CounterApp.Program.main(String[] args) in Component Examples/Examples.CounterApp/Program.fs:line 36
```

This seems to have been introduced last year in the Avalonia repo since setting this property was considered a hack, so let's remove it from FuncUI as well to avoid head scratches from confused users.

PR with the setter set to private:
https://github.com/AvaloniaUI/Avalonia/pull/10370