### PR TITLE
Add a NuGet description property to the Elmish project.

### DIFF
--- a/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
+++ b/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
@@ -11,6 +11,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Avalonia FuncUI Elmish</Title>
     <PackageVersion>$(FuncUIVersion)</PackageVersion>
+    <Description>Elmish integration for Avalonia.FuncUI</Description>
     <PackageIcon>nuget_icon.png</PackageIcon>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
I thought this had been done a while back, but apparently not -

![image](https://github.com/fsprojects/Avalonia.FuncUI/assets/1178570/a803313c-6fad-4f43-8716-432b3c071239)
