### PR TITLE
Add generic RoutedEvent bindings as Attached Event.

### DIFF
--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog.fsproj
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog.fsproj
@@ -27,6 +27,7 @@
         <Compile Include="Views\Tabs\WindowMenuDemo.fs" />
         <Compile Include="Views\Tabs\FlyoutDemo.fs" />
         <Compile Include="Views\Tabs\DragDropDemo.fs" />
+        <Compile Include="Views\Tabs\AttachedEventDemo.fs" />
         <Compile Include="Views\MainView.fs" />
 		<Compile Include="ControlCatalog.fs" />
         <AvaloniaResource Include="**\*.xaml" />

--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/MainView.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/MainView.fs
@@ -112,5 +112,9 @@ module MainView =
                     TabItem.header "WrapPanel Demo"
                     TabItem.content (ViewBuilder.Create<WrapPanelDemo.Host>([]))
                 ]
+                TabItem.create [
+                    TabItem.header "Attached Event Demo"
+                    TabItem.content (ViewBuilder.Create<AttachedEventDemo.Host>([]))
+                ]
             ]
         ]

--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/Tabs/AttachedEventDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/Tabs/AttachedEventDemo.fs
@@ -1,0 +1,162 @@
+namespace Avalonia.FuncUI.ControlCatalog.Views
+
+module AttachedEventDemo =
+    open Avalonia
+    open Avalonia.Controls
+    open Avalonia.Layout
+    open Avalonia.Input
+    open Avalonia.Interactivity
+    open Elmish
+    open Avalonia.FuncUI
+    open Avalonia.FuncUI.DSL
+    open Avalonia.FuncUI.Elmish
+
+    type State = { count: int; input: int; info: string }
+
+    let init () =
+        { count = 0; input = 0; info = "" }, Cmd.none
+
+    type Msg =
+        | Increment
+        | Decrement
+        | SetInput of int
+        | SetCount of int
+        | Reset
+        | SetInfo of string
+
+    let update (msg: Msg) (state: State) : State * Cmd<_> =
+        match msg with
+        | Increment -> { state with count = state.count + 1 }, Cmd.none
+        | Decrement -> { state with count = state.count - 1 }, Cmd.none
+        | SetInput input -> { state with input = input }, Cmd.none
+        | SetCount count -> { state with count = count }, Cmd.none
+        | Reset -> init ()
+        | SetInfo info -> { state with info = info }, Cmd.none
+
+    let (|Name|_|) name (x: obj) : 't option when 't :> StyledElement =
+        match x with
+        | :? 't as t when t.Name = name -> Some t
+        | _ -> None
+
+    let sprintRoutedEvent (s: #Interactive) (e: #RoutedEventArgs) =
+        let time = System.DateTime.Now.ToString ("HH:mm:ss.fff")
+
+        let sender =
+            if System.String.IsNullOrEmpty s.Name then
+                s.GetType().Name
+            else
+                $"{s.GetType().Name}#{s.Name}"
+
+        let source =
+            match e.Source with
+            | :? Interactive as i -> $"{i.GetType().Name}#{i.Name}"
+            | _ -> e.Source.GetType().Name
+
+        $"{time}: {sender} handled {e.RoutedEvent.Name} in {source}"
+
+    let checkNumText input dispatch onFixed =
+        let fixedInput = input |> String.filter System.Char.IsNumber
+        if input <> fixedInput then
+            SetInfo $"Fixed \"{input}\" -> \"{fixedInput}\"" |> dispatch
+        onFixed fixedInput
+
+    let view (state: State) (dispatch) =
+
+        DockPanel.create [
+            DockPanel.name "Root"
+            DockPanel.attachedEvent (
+                InputElement.PointerEnteredEvent,
+                fun (s, e) -> sprintRoutedEvent s e |> SetInfo |> dispatch
+            )
+            DockPanel.attachedEvent (
+                InputElement.PointerExitedEvent,
+                fun (s, e) -> sprintRoutedEvent s e |> SetInfo |> dispatch
+            )
+            DockPanel.attachedEvent<_, TextInputEventArgs> (
+                TextBox.TextInputEvent,
+                fun (s, e) ->
+                    sprintRoutedEvent s e |> SetInfo |> dispatch
+
+                    match e.Source with
+                    | Name (nameof SetInput) _ ->
+                        checkNumText e.Text dispatch e.set_Text
+                    | _ -> ()
+            )
+            DockPanel.attachedEvent<_, TextChangedEventArgs> (
+                TextBox.TextChangedEvent,
+                fun (_, e) ->
+                    match e.Source with
+                    | Name (nameof SetInput) (tb: TextBox) ->
+                        checkNumText tb.Text dispatch (fun fixedInput ->
+                            if tb.Text <> fixedInput then
+                                tb.Text <- fixedInput
+                            int32 fixedInput |> SetInput |> dispatch
+                        )
+                    | _ -> ()
+            )
+            DockPanel.attachedEvent<_, RoutedEventArgs> (
+                Button.ClickEvent,
+                (fun (s, e) ->
+                    match e.Source with
+                    | Name (nameof Increment) _ -> Increment |> dispatch
+                    | Name (nameof Decrement) _ -> Decrement |> dispatch
+                    | Name (nameof Reset) _ -> Reset |> dispatch
+                    | Name (nameof SetCount) _ -> SetCount state.input |> dispatch
+                    | _ -> ()
+
+                    sprintRoutedEvent s e |> SetInfo |> dispatch),
+                OnChangeOf state.input
+            )
+
+            DockPanel.children [
+                TextBlock.create [
+                    TextBlock.name (nameof state.info)
+                    TextBlock.dock Dock.Bottom
+                    TextBlock.text state.info
+                ]
+                Button.create [
+                    Button.name (nameof Reset)
+                    Button.dock Dock.Bottom
+                    Button.horizontalAlignment HorizontalAlignment.Stretch
+                    Button.horizontalContentAlignment HorizontalAlignment.Center
+                    Button.content "reset"
+                ]
+                Button.create [
+                    Button.name (nameof Decrement)
+                    Button.dock Dock.Bottom
+                    Button.horizontalAlignment HorizontalAlignment.Stretch
+                    Button.horizontalContentAlignment HorizontalAlignment.Center
+                    Button.content "-"
+                ]
+                Button.create [
+                    Button.name (nameof Increment)
+                    Button.dock Dock.Bottom
+                    Button.horizontalAlignment HorizontalAlignment.Stretch
+                    Button.horizontalContentAlignment HorizontalAlignment.Center
+                    Button.content "+"
+                ]
+                TextBox.create [
+                    TextBox.name (nameof SetInput)
+                    TextBox.dock Dock.Bottom
+                    TextBox.text (string state.input)
+                    TextBox.innerRightContent (Button.create [ Button.name (nameof SetCount); Button.content "Set" ])
+                ]
+                TextBlock.create [
+                    TextBlock.name (nameof state.count)
+                    TextBlock.dock Dock.Top
+                    TextBlock.fontSize 48.0
+                    TextBlock.verticalAlignment VerticalAlignment.Center
+                    TextBlock.horizontalAlignment HorizontalAlignment.Center
+                    TextBlock.text (string state.count)
+                ]
+            ]
+        ]
+
+    type Host() as this =
+        inherit Hosts.HostControl()
+
+        do
+            Elmish.Program.mkProgram init update view
+            |> Program.withHost this
+            |> Program.withConsoleTrace
+            |> Program.runWithAvaloniaSyncDispatch ()

--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -61,6 +61,7 @@
 
 
     <Compile Include="DSL\Base\Layoutable.fs" />
+    <Compile Include="DSL\Base\Interactive.fs" />
     <Compile Include="DSL\Base\Visual.fs" />
     <Compile Include="DSL\Base\InputElement.fs" />
     <Compile Include="DSL\Base\Control.fs" />

--- a/src/Avalonia.FuncUI/DSL/AttrBuilder.fs
+++ b/src/Avalonia.FuncUI/DSL/AttrBuilder.fs
@@ -48,6 +48,8 @@ module private Helpers =
 
 type Comparer = obj * obj -> bool
 
+type SubscriptionFactory<'arg> = AvaloniaObject * ('arg -> unit) * CancellationToken -> unit
+
 [<AbstractClass; Sealed>]
 type AttrBuilder<'view>() =
 

--- a/src/Avalonia.FuncUI/DSL/Base/Interactive.fs
+++ b/src/Avalonia.FuncUI/DSL/Base/Interactive.fs
@@ -1,0 +1,59 @@
+namespace Avalonia.FuncUI.DSL
+
+open System
+
+open Avalonia
+open Avalonia.Interactivity
+open Avalonia.Controls
+open Avalonia.Layout
+open Avalonia.VisualTree
+open Avalonia.Reactive
+
+[<AutoOpen>]
+module Interactive =
+    open Avalonia.FuncUI
+    open Avalonia.FuncUI.Types
+    open Avalonia.FuncUI.Builder
+    open Avalonia.Data
+    let create (attrs: IAttr<Interactive> list): IView<Interactive> =
+        ViewBuilder.Create<Interactive>(attrs)
+
+    type Interactive with
+        
+        /// <summary>
+        /// Create a Routed Event subscription as attached event.
+        /// </summary>
+        /// 
+        /// <param name="routedEvent">The routed event to subscribe to.</param>
+        /// <param name="func">The function to call when the event is raised. Arguments are current control(sender) and routed event args.</param>
+        /// <param name="subPatchOptions">The subscription patch options.</param>
+        static member attachedEvent<'t when 't :> Interactive>(routedEvent:RoutedEvent, func, ?subPatchOptions) : IAttr<'t> =
+            let factory: SubscriptionFactory<'t * RoutedEventArgs> =
+                fun (control, func, token) ->
+                    let control = control :?> 't
+                    let handler = EventHandler<RoutedEventArgs>(fun s e -> func (s :?> 't, e))
+                    
+                    control.AddHandler(routedEvent, handler, routedEvent.RoutingStrategies)
+                    token.Register(fun () -> control.RemoveHandler(routedEvent, handler)) |> ignore
+
+            let name = $"{nameof<'t>}.{routedEvent.Name}"
+            AttrBuilder<'t>.CreateSubscription<'t * RoutedEventArgs>(name, factory, func, ?subPatchOptions = subPatchOptions)
+
+        /// <summary>
+        /// Create a Routed Event subscription as attached event.
+        /// </summary>
+        /// 
+        /// <param name="routedEvent">The routed event to subscribe to.</param>
+        /// <param name="func">The function to call when the event is raised. Arguments are current control(sender) and routed event args.</param>
+        /// <param name="subPatchOptions">The subscription patch options.</param>
+        static member attachedEvent<'t , 'arg when 't :> Interactive and 'arg :> RoutedEventArgs>(routedEvent: RoutedEvent<'arg>, func, ?subPatchOptions) : IAttr<'t> =
+            let factory: SubscriptionFactory<'t * 'arg> =
+                fun (control, func, token) ->
+                    let control = control :?> 't                    
+                    let handler = EventHandler<'arg>(fun s e -> func (s :?> 't, e))
+
+                    control.AddHandler<'arg>(routedEvent, handler, routedEvent.RoutingStrategies)
+                    token.Register(fun () -> control.RemoveHandler(routedEvent, handler)) |> ignore
+
+            let name = $"{nameof<'t>}.{routedEvent.Name}"
+            AttrBuilder<'t>.CreateSubscription<'t * 'arg>(name, factory, func, ?subPatchOptions = subPatchOptions)


### PR DESCRIPTION
There are times when you want to know the current state of the sender in a RoutedEvent.
This PR adds generic bindings that can be used in such cases.