### PR TITLE
Try to get the control catalog working in NativeAOT builds

### DIFF
--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog.Desktop/Avalonia.FuncUI.ControlCatalog.Desktop.fsproj
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog.Desktop/Avalonia.FuncUI.ControlCatalog.Desktop.fsproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="..\Avalonia.FuncUI.ControlCatalog\Avalonia.FuncUI.ControlCatalog.fsproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <TrimmerRootAssembly Include="Avalonia.FuncUI.ControlCatalog" />
+  </ItemGroup>
+	
 </Project>

--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog.fsproj
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog.fsproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
+        <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/Tabs/DataTemplateDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/Tabs/DataTemplateDemo.fs
@@ -161,7 +161,7 @@ module DataTemplateDemo =
                 TextBlock.create [
                     TextBlock.dock Dock.Top
                     TextBlock.margin 5.0
-                    TextBlock.text (sprintf "Total Products: %i" state.Products.Length)
+                    TextBlock.text ($"Total Products: %i{state.Products.Length}")
                 ]    
                 
                 productDetailsView state.Selected dispatch

--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/Tabs/DragDropDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/Tabs/DragDropDemo.fs
@@ -29,7 +29,7 @@ module DragDropDemo =
     let doDrag (e, dragCount) =
         async {
             let dragData = DataObject()
-            dragData.Set(DataFormats.Text, sprintf "You have dragged text %d times" dragCount)
+            dragData.Set(DataFormats.Text, $"You have dragged text %d{dragCount} times")
 
             let! result = Dispatcher.UIThread.InvokeAsync<DragDropEffects>
                               (fun _ -> DragDrop.DoDragDrop(e, dragData, DragDropEffects.Copy)) |> Async.AwaitTask

--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/Tabs/GridDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/Tabs/GridDemo.fs
@@ -48,8 +48,8 @@ module GridDemo =
                     )
                 ]
                 Grid.create [
-                    Grid.columnDefinitions (sprintf "%i, 1*" state.cellWidth)
-                    Grid.rowDefinitions (sprintf "%i, 1*" state.cellHeight)
+                    Grid.columnDefinitions ($"%i{state.cellWidth}, 1*")
+                    Grid.rowDefinitions ($"%i{state.cellHeight}, 1*")
                     Grid.showGridLines true
                     Grid.children [
                         Border.create [


### PR DESCRIPTION
The main issue besides the dynamically loaded xaml being trimmed out (avoided for now by rooting the control catalog assembly) is that it seems to not like using ```sprintf``` in views, e.g.

```
Unhandled Exception: System.NotSupportedException: 'Microsoft.FSharp.Core.PrintfImpl+Specializations`3[Microsoft.FSharp.Core.Unit,System.String,System.String].CaptureFinal1[System.Int32](Microsoft.FSharp.Core.PrintfImpl+Step[])' is missing native code. MethodInfo.MakeGenericMethod() is not compatible with AOT compilation. Inspect and fix AOT related warnings that were generated when the app was published. For more information see https://aka.ms/nativeaot-compatibility
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x2f
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x189
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.buildCaptureFunc[a](PrintfImpl.FormatSpecifier, a, Type[], Type, Tuple`5) + 0x21b
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.parseAndCreateFuncFactoryAux(FSharpList`1, String, Type, Int32&) + 0x22c
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.parseAndCreateFunctionFactory() + 0x78
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.GetCurriedPrinterFactory() + 0x1f
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.GetCurriedStringPrinter() + 0x20
   at Avalonia.FuncUI.ControlCatalog.Views.DataTemplateDemo.view(DataTemplateDemo.State state, FSharpFunc`2 dispatch) + 0xae
   at Avalonia.FuncUI.ControlCatalog.Views.MainView.view(MainView.CounterState state, FSharpFunc`2 dispatch) + 0x64e
   at Avalonia.FuncUI.Elmish.Program.withHost@14.Invoke(model, FSharpFunc`2) + 0x78
   at Elmish.ProgramModule.runWithDispatch[msg,arg,model,view](FSharpFunc`2, arg, Program`4) + 0x200
   at Avalonia.FuncUI.ControlCatalog.App.OnFrameworkInitializationCompleted() + 0x11c
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime(AppBuilder, String[], Action`1) + 0x2f
   at Avalonia.FuncUI.ControlCatalog.Desktop!<BaseAddress>+0xa51d70
```

```
Unhandled Exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.NotSupportedException: 'Microsoft.FSharp.Core.PrintfImpl+Specializations`3[Microsoft.FSharp.Core.Unit,System.String,System.String].CaptureFinal1[System.Int32](Microsoft.FSharp.Core.PrintfImpl+Step[])' is missing native code. MethodInfo.MakeGenericMethod() is not compatible with AOT compilation. Inspect and fix AOT related warnings that were generated when the app was published. For more information see https://aka.ms/nativeaot-compatibility
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x2f
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x189
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.buildCaptureFunc[a](PrintfImpl.FormatSpecifier, a, Type[], Type, Tuple`5) + 0x21b
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.parseAndCreateFuncFactoryAux(FSharpList`1, String, Type, Int32&) + 0x22c
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.parseAndCreateFunctionFactory() + 0x78
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.GetCurriedPrinterFactory() + 0x1f
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.GetCurriedStringPrinter() + 0x20
   at Avalonia.FuncUI.ControlCatalog.Views.GridDemo.view(GridDemo.State state, FSharpFunc`2 dispatch) + 0x52c
```
But changing those to use interpolated strings rather than sprintf seems to fix it - after that it seems to run ok (On Windows at least - haven't tried it on anything else yet)