### PR TITLE
Fix spelling/grammar errors in the docs

### DIFF
--- a/docs/common-questions.md
+++ b/docs/common-questions.md
@@ -2,7 +2,7 @@
 
 ## How do I obtain the reference of a Control?
 
-There are 2 recommended ways of obtaining the reference of an underlaying control. \
+There are 2 recommended ways of obtaining the reference of an underlying control. \
 
 
 ### 1. Execute code on control creation
@@ -68,7 +68,7 @@ Component(fun ctx ->
 
 ## How do I restrict what a user can input in a TextBox / AutoCompleteBox / InputElement ?
 
-This is possible by intercepting the [TextInputEvent](https://reference.avaloniaui.net/api/Avalonia.Input/InputElement/FEA4DB21) and modifying its event args. It's important to attache the handler to the tunnelled event. More details about event routing can be found [here](https://docs.avaloniaui.net/docs/input/routed-events#routing-strategies). \
+This is possible by intercepting the [TextInputEvent](https://reference.avaloniaui.net/api/Avalonia.Input/InputElement/FEA4DB21) and modifying its event args. It's important to attach the handler to the tunnelled event. More details about event routing can be found [here](https://docs.avaloniaui.net/docs/input/routed-events#routing-strategies). \
 \
 In the example below whatever a user types in a TextBox will end up as uppercase text.&#x20;
 

--- a/docs/components/component-basics.md
+++ b/docs/components/component-basics.md
@@ -6,7 +6,7 @@ There are two ways of creating a component.&#x20;
 
 ## Component (fun ctx -> ...)
 
-Creating a component using the regular constructor of the `Component` class. `Component` inherits from `Border` and therefor can be used like any other Avalonia control.
+Creating a component using the regular constructor of the `Component` class. `Component` inherits from `Border` and therefore can be used like any other Avalonia control.
 
 ```fsharp
 // create a Component that can be directly used in a Avalonia app
@@ -32,7 +32,7 @@ control.Content <- component
 
 ## Component.create ("key", fun ctx -> ...)
 
-Declaratlvely describes a component. Can be embedded in other views as this returns an `IView`
+Declaratively describes a component. Can be embedded in other views as this returns an `IView`
 
 ```fsharp
 let greetingView (): IView = 

--- a/docs/components/component-lifetime.md
+++ b/docs/components/component-lifetime.md
@@ -52,7 +52,7 @@ type Views () =
         )
 ```
 
-Instead of removing the `Button` from the Virtual DOM we can also just set `isVisible` accordingly. This does not change the location of the `randomColorView` and will keep it's identity.
+Instead of removing the `Button` from the Virtual DOM we can also just set `isVisible` accordingly. This does not change the location of the `randomColorView` and will keep its identity.
 
 ```fsharp
 ..    
@@ -81,7 +81,7 @@ Instead of removing the `Button` from the Virtual DOM we can also just set `isVi
 
 ## Component Identity - Key
 
-A Components identity can be explicitly changed by changing it's key. This is useful when the location is stable, but you still want to get a new component in some cases.&#x20;
+A Components identity can be explicitly changed by changing its key. This is useful when the location is stable, but you still want to get a new component in some cases.&#x20;
 
 ```fsharp
 type Views () =

--- a/docs/components/hooks.md
+++ b/docs/components/hooks.md
@@ -2,7 +2,7 @@
 
 ### useState
 
-This is the most basic hook which allows you to create an instance of a value which can be both read and updated in your component's code, the state is kept between renders and any updates to it will cause it to re-render by default
+This is the most basic hook which allows you to create an instance of a value which can be both read and updated in your component's code, the state is kept between renders and any updates to it will cause it to re-render by default.
 
 ```fsharp
 Component(fun ctx ->
@@ -57,7 +57,7 @@ Component("use-effect-component", fun ctx ->
 )
 ```
 
-We can also re-execute these handlers if we make them dependant of any readable values, for example let us try to compute the sum of the ages of a user list whenever the user list changes.
+We can also re-execute these handlers if we make them dependent on any readable values, for example let us try to compute the sum of the ages of a user list whenever the user list changes.
 
 ```fsharp
 Component("use-effect-component", fun ctx ->
@@ -102,9 +102,9 @@ As is in the source comments:
 
 > Readable state value that can be subscribed to.
 
-Readables are values which you can subscribe to get updates, this are common values used
+Readables are values to which you can subscribe to get updates, these are commonly used values.
 
-An example would be the following
+An example would be the following:
 
 ```fsharp
 Component(fun ctx ->
@@ -116,7 +116,7 @@ Component(fun ctx ->
 )
 ```
 
-At this point this component will be pretty much static, it won't ever be re-rendered because there are no changes to it's state.
+At this point this component will be pretty much static, it won't ever be re-rendered because there are no changes to its state.
 
 ### IWritable<'T>
 
@@ -130,7 +130,7 @@ As is in the source comments:
 
 > Readable and writable state value that can be subscribed to.
 
-If we take the previous example and add mutations it would look like the following:
+If we take the previous example and add mutations, it would look like the following:
 
 ```fsharp
 Component(fun ctx ->

--- a/docs/view-basics/attributes.md
+++ b/docs/view-basics/attributes.md
@@ -32,7 +32,7 @@ In the example below the handler function captures `current` . When the button i
 
 <figure><img src="../.gitbook/assets/Screenshot 2023-11-10 at 09.34.54.png" alt=""><figcaption></figcaption></figure>
 
-Capturing state that changes over time should be avoided is most cases. You can provide FuncUI with a way of knowing when to update your handler function. \
+Capturing state that changes over time should be avoided in most cases. You can provide FuncUI with a way of knowing when to update your handler function. \
 \
 Update handler function on render if current value changed:
 
@@ -52,7 +52,7 @@ Button.onClick (
 )
 ```
 
-By default the handler function is only updated if the underlaying delegate type changes.
+By default, the handler function is only updated if the underlying delegate type changes.
 
 ### 🧲 Attached Properties
 

--- a/docs/view-basics/creating-views.md
+++ b/docs/view-basics/creating-views.md
@@ -1,10 +1,10 @@
 # Creating views
 
-There are multipe ways of creating a view for a certain control. They all have in common that the resulting type is `IView` or `IView<'t>`.
+There are multiple ways of creating a view for a certain control. They all have in common that the resulting type is `IView` or `IView<'t>`.
 
 ## Creating views for common controls
 
-FuncUI provides functions for creating standard avalonia controls. The create function always follows the same pattern.\
+FuncUI provides functions for creating standard Avalonia controls. The create function always follows the same pattern.\
 
 
 <pre class="language-fsharp" data-title="internal - signature"><code class="lang-fsharp"><strong>module Button =
@@ -27,7 +27,7 @@ So the create function for a `TextBlock` is `TextBlock.create`, for a `StackPane
 
 ## Creating views for custom controls
 
-Even without creating bindings for a control you can create and embedd it in a view.&#x20;
+Even without creating bindings for a control you can create and embed it in a view.&#x20;
 
 ```fsharp
 View.createGeneric<MyCustomControl> [
@@ -37,7 +37,7 @@ View.createGeneric<MyCustomControl> [
 
 ### Passing constructor arguments
 
-Sometimes controls dont have a unit constructor and need constructor arguments. Here is how you  can pass them.
+Sometimes controls don't have a unit constructor and need constructor arguments. Here is how you  can pass them.
 
 ```fsharp
 [

--- a/docs/view-basics/how-to-create-bindings.md
+++ b/docs/view-basics/how-to-create-bindings.md
@@ -1,6 +1,6 @@
 # How to create bindings
 
-Creating bindings for avalonia controls is fairly easy. You just need to know a little bit about the source of the control and its public properties/events.
+Creating bindings for Avalonia controls is fairly easy. You just need to know a little bit about the source of the control and its public properties/events.
 
 You can create bindings for any public styled/direct properties for example the `IsPressed` [Property of Button.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Button.cs#L78)
 

--- a/docs/view-basics/lifetime.md
+++ b/docs/view-basics/lifetime.md
@@ -1,16 +1,16 @@
 # Lifetime
 
-Every FuncUI view is backed by an Avalonia Control. Even when attributes of a view change, the backing control does not change. Instead changes are mirrored to the backing Control. This is often called "patching".
+Every FuncUI view is backed by an Avalonia Control. Even when attributes of a view change, the backing control does not change. Instead, changes are mirrored to the backing Control. This is often called "patching".
 
 <img src="../.gitbook/assets/file.excalidraw.svg" alt="" class="gitbook-drawing">
 
-Views don't hold a reference to their backing avalonia control. The backing control is determined by the view structore.&#x20;
+Views don't hold a reference to their backing Avalonia control. The backing control is determined by the view structure.&#x20;
 
 <img src="../.gitbook/assets/file.excalidraw (1).svg" alt="" class="gitbook-drawing">
 
-This means if the structore changes the backing control also does change. FuncUI will ensure the new backing control is patched / has all attributes set as specified in the view.
+This means if the structure changes the backing control also does change. FuncUI will ensure the new backing control is patched / has all attributes set as specified in the view.
 
-If the view type in the structure does not match the view tyoe in the backing structure a new backing control is created.
+If the view type in the structure does not match the view type in the backing structure a new backing control is created.
 
 <img src="../.gitbook/assets/file.excalidraw (2).svg" alt="" class="gitbook-drawing">
 
@@ -20,7 +20,7 @@ Only backing views of the same type can be reused when the view structure change
 
 ## Keyed Views
 
-Sometimes you need more control over the reuse of backing controls. This can be archived by specifying a view key.\
+Sometimes you need more control over the reuse of backing controls. This can be achieved by specifying a view key.\
 \
 If the view key changes a new backing view is created, no patching is attempted.&#x20;
 


### PR DESCRIPTION
I was reading the docs and noticed some spelling errors, so I went and fixed those that I saw.