### PR TITLE
Replace a sprintf in the Tetris example with a string interpolation

### DIFF
--- a/src/Examples/Elmish Examples/Examples.Elmish.Tetris/View.fs
+++ b/src/Examples/Elmish Examples/Examples.Elmish.Tetris/View.fs
@@ -109,7 +109,7 @@ module View =
                         [ TextBlock.fontSize 16.
                           TextBlock.horizontalAlignment HorizontalAlignment.Center
                           TextBlock.width 350.
-                          TextBlock.text (sprintf "Score: %d " state.score) ] ] ]
+                          TextBlock.text ($"Score: %d{state.score}" ) ] ] ]
 
     let howToPlayView =
         StackPanel.create


### PR DESCRIPTION
I tried doing a NativeAOT build of the Tetris example on top of #413 to see if it worked and got

```
GenericMethod() is not compatible with AOT compilation. Inspect and fix AOT related warnings that were generated when the app was published. For more information see https://aka.ms/nativeaot-compatibility
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x2f
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x189
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.buildCaptureFunc[a](PrintfImpl.FormatSpecifier, a, Type[], Type, Tuple`5) + 0x245
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.parseAndCreateFuncFactoryAux(FSharpList`1, String, Type, Int32&) + 0x22c
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.parseAndCreateFunctionFactory() + 0x78
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.GetCurriedPrinterFactory() + 0x1f
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.GetCurriedStringPrinter() + 0x20
   at Example.Tetris.View.menuView[a](Game.State, a) + 0x191
   at Example.Tetris.View.view$cont@142(Game.State, FSharpFunc`2, Unit) + 0xa0
   at Avalonia.FuncUI.Elmish.Program.withHost@14.Invoke(model, FSharpFunc`2) + 0x78
   at Elmish.ProgramModule.runWithDispatch[msg,arg,model,view](FSharpFunc`2, arg, Program`4) + 0x200
   at Example.Tetris.MainWindow..ctor() + 0x21e
   at Example.Tetris.App.OnFrameworkInitializationCompleted() + 0x26
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime(AppBuilder, String[], Action`1) + 0x2f
   at Examples.Elmish.Tetris!<BaseAddress>+0x99a8d3
```

and changing the sprintf to an interpolation seems to fix it (after that change, the AOT build seems to be fully functional on Windows, haven't tried any other platforms)