### PR TITLE
Add ToggleType and related properties to MenuItem

### DIFF
--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/Tabs/WindowMenuDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/Tabs/WindowMenuDemo.fs
@@ -31,10 +31,12 @@ module WindowMenuDemo =
                                 MenuItem.create [
                                     MenuItem.header "Light"
                                     MenuItem.onClick (fun _ -> "#e74c3c" |> SetColor |> dispatch)
+                                    MenuItem.toggleType MenuItemToggleType.Radio
                                 ]
                                 MenuItem.create [
                                     MenuItem.header "Dark"
                                     MenuItem.onClick (fun _ -> "#c0392b" |> SetColor |> dispatch)
+                                    MenuItem.toggleType MenuItemToggleType.Radio
                                 ]  
                             ]
                         ] 

--- a/src/Avalonia.FuncUI/DSL/MenuItem.fs
+++ b/src/Avalonia.FuncUI/DSL/MenuItem.fs
@@ -61,3 +61,12 @@ module MenuItem =
 
         static member onSubMenuOpened<'t when 't :> MenuItem>(func: RoutedEventArgs -> unit, ?subPatchOptions) =
             AttrBuilder<'t>.CreateSubscription<RoutedEventArgs>(MenuItem.SubmenuOpenedEvent, func, ?subPatchOptions = subPatchOptions)
+
+        static member toggleType<'t when 't :> MenuItem>(toggleType: MenuItemToggleType) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<MenuItemToggleType>(MenuItem.ToggleTypeProperty, toggleType, ValueNone)
+
+        static member isChecked<'t when 't :> MenuItem>(isChecked: bool) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<bool>(MenuItem.IsCheckedProperty, isChecked, ValueNone)
+
+        static member groupName<'t when 't :> MenuItem>(groupName: string) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<string>(MenuItem.GroupNameProperty, groupName, ValueNone)


### PR DESCRIPTION
Added to Avalonia in https://github.com/AvaloniaUI/Avalonia/pull/11441

refs #431 

Also adds radio buttons to the control catalog menu page as a really simple example:

![toggle](https://github.com/user-attachments/assets/1a026e46-1fc9-4041-b2cc-1af654b2e9b5)
