### PR TITLE
fix: remove invalid usages of RequireQualifiedAccess

### DIFF
--- a/src/Avalonia.FuncUI/Components/Context/Context.StateHook.fs
+++ b/src/Avalonia.FuncUI/Components/Context/Context.StateHook.fs
@@ -17,7 +17,7 @@ type StateHookError =
                 "    This usually means a component key should have changed, but it didn't."
             ]
 
-[<RequireQualifiedAccess; Struct; IsReadOnly>]
+[<Struct; IsReadOnly>]
 type StateHookValueResolver =
     | Const of constant: IAnyReadable
     | Lazy of factory: (unit -> IAnyReadable)

--- a/src/Avalonia.FuncUI/Components/State/State.fs
+++ b/src/Avalonia.FuncUI/Components/State/State.fs
@@ -5,7 +5,7 @@ open Avalonia.FuncUI
 
 
 /// Used to create a dependency graph of state values for debugging / visualization.
-[<Struct; RequireQualifiedAccess>]
+[<Struct>]
 type InstanceType =
     | Source
     | Adapter of sources: Map<string, IAnyReadable>

--- a/src/Avalonia.FuncUI/DSL/Panels/Grid.fs
+++ b/src/Avalonia.FuncUI/DSL/Panels/Grid.fs
@@ -5,7 +5,6 @@ module ColumnDefinition =
     open Avalonia.Controls
     
     [<Struct>]
-    [<RequireQualifiedAccess>]
     type ColumnWidth =
     /// Column is auto-sized to fit it's contents
     | Auto
@@ -37,7 +36,6 @@ module RowDefinition =
     open Avalonia.Controls
 
     [<Struct>]
-    [<RequireQualifiedAccess>]
     type RowHeight =
     /// Row is auto-sized to fit it's contents
     | Auto


### PR DESCRIPTION
This allows building on systems with dotnet 9 installed, and has zero behavioral impact. 

An alternative way to allow building on systems that have dotnet 9 installed would be to generate a global.json file that specifies sdk version 8.