### PR TITLE
Add a global.json to pin the builds to the .NET 8 SDK for now

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.400",
+    "rollForward": "minor"
+  }
+}


### PR DESCRIPTION
refs https://github.com/fsprojects/Avalonia.FuncUI/issues/449

I was going to update FSharp.Core to 8.0.300, but then I see there are discussions in https://github.com/dotnet/fsharp/issues/18298 about reverting the compiler changes, so maybe we should see where that goes before making public changes