### PR TITLE
Use XCode 16 in the CI builds

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: xCode
-      run: sudo xcode-select -s /Applications/Xcode_15.1.app/Contents/Developer/
+      run: sudo xcode-select -s /Applications/Xcode_16.app/Contents/Developer/
 
     - uses: actions/checkout@v4
     - name: Setup .NET

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -7,11 +7,11 @@ on:
 jobs:
   build:
 
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
     - name: xCode
-      run: sudo xcode-select -s /Applications/Xcode_16.app/Contents/Developer/
+      run: sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer/
 
     - uses: actions/checkout@v4
     - name: Setup .NET


### PR DESCRIPTION
The CI build now seems to be having issues building the iOS examples:

```
ILLINK : error MT0180: This version of Microsoft.iOS requires the iOS 18.0 SDK (shipped with Xcode 16.0). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options > Linker Behavior (to try to avoid the new APIs). [/Users/runner/work/Avalonia.FuncUI/Avalonia.FuncUI/src/Examples/Examples.Mobile.iOS/Examples.Mobile.iOS.fsproj]
ILLINK : error MT2301: The linker step 'Setup' failed during processing: This version of Microsoft.iOS requires the iOS 18.0 SDK (shipped with Xcode 16.0). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options > Linker Behavior (to try to avoid the new APIs). [/Users/runner/work/Avalonia.FuncUI/Avalonia.FuncUI/src/Examples/Examples.Mobile.iOS/Examples.Mobile.iOS.fsproj]
Error: /Users/runner/.nuget/packages/microsoft.net.illink.tasks/8.0.13/build/Microsoft.NET.ILLink.targets(87,5): error NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false. [/Users/runner/work/Avalonia.FuncUI/Avalonia.FuncUI/src/Examples/Examples.Mobile.iOS/Examples.Mobile.iOS.fsproj]
```

So, try updating xcode from 15.1 to 16.
(I don't have a mac to hand to test this - just testing it in the CI)