### PR TITLE
Make the nuget badge in the readme a link to the nuget.org page for t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Avalonia FuncUI
 <img src="https://img.shields.io/github/languages/top/fsprojects/Avalonia.FuncUI" alt="GitHub top language">
 <img alt="GitHub repo size" src="https://img.shields.io/github/repo-size/fsprojects/Avalonia.FuncUI">
 <img src="https://img.shields.io/github/license/fsprojects/Avalonia.FuncUI">
-<img alt="Nuget (with prereleases)" src="https://img.shields.io/nuget/vpre/Avalonia.FuncUI?color=green&label=package%20Avalonia.FuncUI">
+<a href="https://www.nuget.org/packages/Avalonia.FuncUI">
+  <img alt="Nuget (with prereleases)" src="https://img.shields.io/nuget/vpre/Avalonia.FuncUI?color=green&label=package%20Avalonia.FuncUI">
+</a>
 </p><br>
 
 ![](github/img/hero-multiple-apps.png)


### PR DESCRIPTION
…he package

Clicking the nuget package badge at the top of the readme currently just opens the badge image... would it be more useful to link to the nuget.org page instead?