### PR TITLE
Update the PackageProjectUrl links in the project files

### DIFF
--- a/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
+++ b/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
@@ -7,7 +7,7 @@
     <Product>Avalonia.FuncUI.Elmish</Product>
     <PackageId>Avalonia.FuncUI.Elmish</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/FuncUI/Avalonia.FuncUI</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/fsprojects/Avalonia.FuncUI</PackageProjectUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Avalonia FuncUI Elmish</Title>
     <PackageVersion>$(FuncUIVersion)</PackageVersion>

--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -7,7 +7,7 @@
     <Product>Avalonia.FuncUI</Product>
     <PackageId>Avalonia.FuncUI</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/FuncUI/Avalonia.FuncUI</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/fsprojects/Avalonia.FuncUI</PackageProjectUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Avalonia FuncUI</Title>
     <PackageVersion>$(FuncUIVersion)</PackageVersion>


### PR DESCRIPTION
These get used for the 'Project website' links on the nuget.org page.
The existing links get redirected into the fsprojects page, but still better to have the current defaults I think?