### PR TITLE
Move common NuGet package properties into Directory.Build.props

### DIFF
--- a/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
+++ b/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
@@ -3,18 +3,14 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Version>$(FuncUIVersion)</Version>
-    <Authors>JaggerJo</Authors>
     <Product>Avalonia.FuncUI.Elmish</Product>
     <PackageId>Avalonia.FuncUI.Elmish</PackageId>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/fsprojects/Avalonia.FuncUI</PackageProjectUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Avalonia FuncUI Elmish</Title>
     <PackageVersion>$(FuncUIVersion)</PackageVersion>
     <Description>Elmish integration for Avalonia.FuncUI</Description>
     <PackageIcon>nuget_icon.png</PackageIcon>
 
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>

--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -3,18 +3,14 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Version>$(FuncUIVersion)</Version>
-    <Authors>JaggerJo</Authors>
     <Product>Avalonia.FuncUI</Product>
     <PackageId>Avalonia.FuncUI</PackageId>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/fsprojects/Avalonia.FuncUI</PackageProjectUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Avalonia FuncUI</Title>
     <PackageVersion>$(FuncUIVersion)</PackageVersion>
     <Description>Develop cross-plattform MVU GUI Applications using F# and Avalonia!</Description>
     <PackageIcon>nuget_icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,4 +3,12 @@
     <AvaloniaVersion>11.1.0</AvaloniaVersion>
     <FuncUIVersion>1.5.1</FuncUIVersion>
   </PropertyGroup>
+	
+  <!-- Common NuGet package properties -->
+  <PropertyGroup>
+    <Authors>JaggerJo</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/fsprojects/Avalonia.FuncUI</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
refs https://github.com/fsprojects/Avalonia.FuncUI/pull/459#discussion_r2052340926

Should PackageVersion be common as well? (I guess the core lib and the elmish lib should be in step, not sure about the diagnostics lib if that gets published again)