### PR TITLE
Add a binding for Border.BackgroundSizing

### DIFF
--- a/src/Avalonia.FuncUI/DSL/Border.fs
+++ b/src/Avalonia.FuncUI/DSL/Border.fs
@@ -21,7 +21,10 @@ module Border =
 
         static member background<'t when 't :> Border>(color: Color) : IAttr<'t> =
             color |> ImmutableSolidColorBrush |> Border.background
-            
+          
+        static member backgroundSizing<'t when 't :> Border>(sizing: BackgroundSizing) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<BackgroundSizing>(Border.BackgroundSizingProperty, sizing, ValueNone)
+
         static member borderBrush<'t when 't :> Border>(brush: IBrush) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<IBrush>(Border.BorderBrushProperty, brush, ValueNone)
             


### PR DESCRIPTION
Was just having a look over the list of new properties that were added in Avalonia 11.1 that don't have bindings yet, and this new Border.BackgroundSizingProperty``` appears to be one