### PR TITLE
Update BenchmarkDotNet to 0.15.2

### DIFF
--- a/src/Avalonia.FuncUI.Benchmarks/Avalonia.FuncUI.Benchmarks.fsproj
+++ b/src/Avalonia.FuncUI.Benchmarks/Avalonia.FuncUI.Benchmarks.fsproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
I was having a go at doing some comparative benchmarks between .NET 8 and .NET 10 and needed the new version to get the .NET 10 runtime moniker settings, so hopefully there's no issue with just updating it