### PR TITLE
Add native menu and tray icon bindings

### DIFF
--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/ControlCatalog.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/ControlCatalog.fs
@@ -8,6 +8,7 @@ open Avalonia.FuncUI.Elmish
 open Avalonia.FuncUI.ControlCatalog.Views
 open Avalonia.Themes.Fluent
 open Avalonia.FuncUI
+open Avalonia.FuncUI.DSL
 open Avalonia.Controls
 
 type MainWindow() as this =
@@ -26,6 +27,24 @@ type App() =
     inherit Application()
 
     override this.Initialize() =
+        let menu = NativeMenu.create [
+                    NativeMenu.items [
+                        NativeMenuItem.create [
+                            NativeMenuItem.header "File"
+                            NativeMenuItem.isChecked true
+                            NativeMenuItem.isEnabled false
+                        ]
+                    ]
+                ]
+        let tray =
+            TrayIcon.create [
+                TrayIcon.toolTipText "Control Catalog"
+                TrayIcon.menu menu
+            ]
+        let icon = Avalonia.FuncUI.VirtualDom.VirtualDom.createObject tray :?> TrayIcon
+        let icons  = TrayIcons()
+        icons.Add(icon)
+        TrayIcon.SetIcons(this, icons)
         this.Styles.Add (FluentTheme())
         this.Styles.Load "avares://Avalonia.FuncUI.ControlCatalog/Styles/TabControl.xaml"
 

--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -154,8 +154,11 @@
     <Compile Include="DSL\ListBoxItem.fs" />
     <Compile Include="DSL\MenuBase.fs" />
     <Compile Include="DSL\Menu.fs" />
+    <Compile Include="DSL\NativeMenu.fs" />
     <Compile Include="DSL\ContextMenu.fs" />
     <Compile Include="DSL\MenuItem.fs" />
+    <Compile Include="DSL\NativeMenuItem.fs" />
+    <Compile Include="DSL\TrayIcon.fs" />
     <Compile Include="DSL\GridSplitter.fs" />
     <Compile Include="DSL\DatePickerPresenter.fs" />
     <Compile Include="DSL\TimePickerPresenter.fs" />

--- a/src/Avalonia.FuncUI/DSL/NativeMenu.fs
+++ b/src/Avalonia.FuncUI/DSL/NativeMenu.fs
@@ -1,0 +1,16 @@
+﻿namespace Avalonia.FuncUI.DSL
+
+[<AutoOpen>]
+module NativeMenu =
+    open Avalonia.Controls
+    open Avalonia.FuncUI.Builder
+    open Avalonia.FuncUI.Types
+     
+    let create (attrs: IAttr<NativeMenu> list): IView<NativeMenu> =
+        ViewBuilder.Create<NativeMenu>(attrs)
+     
+    type NativeMenu with
+         static member items<'t when 't :> NativeMenu>(value: IView list) : IAttr<'t> =
+            let getter : ('t -> obj) = (fun control -> control.Items :> obj)
+
+            AttrBuilder<'t>.CreateContentMultiple("Items", ValueSome getter, ValueNone, value)

--- a/src/Avalonia.FuncUI/DSL/NativeMenuItem.fs
+++ b/src/Avalonia.FuncUI/DSL/NativeMenuItem.fs
@@ -1,0 +1,30 @@
+﻿namespace Avalonia.FuncUI.DSL
+open Avalonia.Input
+open Avalonia.Interactivity
+open System.Windows.Input
+
+[<AutoOpen>]
+module NativeMenuItem =
+    open Avalonia.Controls
+    open Avalonia.FuncUI.Types
+    open Avalonia.FuncUI.Builder
+
+    let create (attrs: IAttr<NativeMenuItem> list): IView<NativeMenuItem> =
+        ViewBuilder.Create<NativeMenuItem>(attrs)
+
+    type NativeMenuItem with
+
+        static member command<'t when 't :> NativeMenuItem>(command: ICommand) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<ICommand>(NativeMenuItem.CommandProperty, command, ValueNone)
+
+        static member commandParameter<'t when 't :> NativeMenuItem>(parameter: obj) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<obj>(NativeMenuItem.CommandParameterProperty, parameter, ValueNone)
+
+        static member header<'t when 't :> NativeMenuItem>(header: string) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<string>(NativeMenuItem.HeaderProperty, header, ValueNone)
+
+        static member isChecked<'t when 't :> NativeMenuItem>(value: bool) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<bool>(NativeMenuItem.IsCheckedProperty, value, ValueNone)
+
+        static member isEnabled<'t when 't :> NativeMenuItem>(value: bool) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<bool>(NativeMenuItem.IsEnabledProperty, value, ValueNone)

--- a/src/Avalonia.FuncUI/DSL/TrayIcon.fs
+++ b/src/Avalonia.FuncUI/DSL/TrayIcon.fs
@@ -1,0 +1,34 @@
+﻿namespace Avalonia.FuncUI.DSL
+open Avalonia.Input
+open Avalonia.Interactivity
+open System.Windows.Input
+
+[<AutoOpen>]
+module TrayIcon =
+    open Avalonia.Controls
+    open Avalonia.FuncUI.Builder
+    open Avalonia.FuncUI.Types
+     
+    let create (attrs: IAttr<TrayIcon> list): IView<TrayIcon> =
+        ViewBuilder.Create<TrayIcon>(attrs)
+     
+    type TrayIcon with
+        static member command<'t when 't :> TrayIcon>(command: ICommand) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<ICommand>(TrayIcon.CommandProperty, command, ValueNone)
+
+        static member commandParameter<'t when 't :> TrayIcon>(parameter: obj) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<obj>(TrayIcon.CommandParameterProperty, parameter, ValueNone)        
+
+        static member isVisible<'t when 't :> TrayIcon>(isVisible: bool) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<bool>(TrayIcon.IsVisibleProperty, isVisible, ValueNone)
+
+        static member toolTipText<'t when 't :> TrayIcon>(toolTipText: string) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<string>(TrayIcon.ToolTipTextProperty, toolTipText, ValueNone)
+
+        static member menu<'t when 't :> TrayIcon>(menu: IView option) : IAttr<'t> =
+            AttrBuilder<'t>.CreateContentSingle(TrayIcon.MenuProperty, menu)
+
+        static member menu<'t when 't :> TrayIcon>(value: IView) : IAttr<'t> =
+            value
+            |> Some
+            |> TrayIcon.menu

--- a/src/Avalonia.FuncUI/VirtualDom/VirtualDom.fs
+++ b/src/Avalonia.FuncUI/VirtualDom/VirtualDom.fs
@@ -4,13 +4,17 @@ open Avalonia.Controls
 
 open Avalonia.FuncUI.Types
 open Avalonia.FuncUI.VirtualDom.Delta
+open Avalonia
 
 module rec VirtualDom =
+    let createObject (view: IView) : AvaloniaObject =
+        view
+        |> ViewDelta.From
+        |> Patcher.create
 
     let create (view: IView) : Control =
         view
-        |> ViewDelta.From
-        |> Patcher.create :?> Control
+        |> createObject :?> Control
 
     let update (root: Control, last: IView, next: IView) : unit =
         let delta = Differ.diff(last, next)


### PR DESCRIPTION
@JaggerJo 
I was taking another look at this and dug a bit deeper into how the render process works and got something working.
```fsharp
    override this.Initialize() =
        let menu = NativeMenu.create [
                    NativeMenu.items [
                        NativeMenuItem.create [
                            NativeMenuItem.header "File"
                            NativeMenuItem.isChecked true
                            NativeMenuItem.isEnabled false
                        ]
                    ]
                ]
        let tray =
            TrayIcon.create [
                TrayIcon.toolTipText "Control Catalog"
                TrayIcon.menu menu
            ]
        let icon = Avalonia.FuncUI.VirtualDom.VirtualDom.createObject tray :?> TrayIcon
        let icons  = TrayIcons()
        icons.Add(icon)
        TrayIcon.SetIcons(this, icons)
```
I still need to make sure I'm not missing any properties in the bindings.

<img width="110" height="103" alt="Image" src="https://github.com/user-attachments/assets/2b63e655-2ede-47f5-931b-a68d2571142c" />

I implemented an additional function in the VirtualDom module to render an AvaloniaObject instead of a Control.

This approach obviously isn't stateful since it only renders once.
I kinda feel like we should maybe come up with some better apis for managing the App object.
But open to your thoughts.

Fixes #427 