### PR TITLE
fixes link

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ type Components =
         )
 ```
 
-Find more examples using components in the [Components Examples folder](https://github.com/fsprojects/Avalonia.FuncUI/tree/master/src/Examples/Component%20Examples).
+Find more examples using components in the [Components Examples folder](https://github.com/fsprojects/Avalonia.FuncUI/tree/master/docs/components).
 
 ### Example using Elmish
 The same counter as above but using the `Avalonia.FuncUI.Elmish` package:


### PR DESCRIPTION
This fixes the currently broken link to the Components folder.

Two questions: 

Is it welcome to also add a bit of a welcoming text to its README? - since that one is currently empty.

And can somebody please tell me, what  `ctx` is supposed to mean?

That is written all over the place, and I don't see it explained at all.

Especially to understand something critical as the initial example, should that be clear.

I would prefer a non-abbreviated name, since that is clear to everybody.

Cheers ✨