### PR TITLE
Update Avalonia to 11.2

### DIFF
--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/Tabs/TimePickerDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/Tabs/TimePickerDemo.fs
@@ -12,19 +12,25 @@ module TimePickerDemo =
       { time: TimeSpan Nullable
         header: string
         minuteIncrement: int
-        clockIdentifier: string }
+        clockIdentifier: string 
+        secondIncrement: int
+        useSeconds: bool }
 
     let init () = 
         { time = Nullable(DateTime.Today.TimeOfDay)
           header = "Header"
           minuteIncrement = 1
-          clockIdentifier = "12HourClock" }
+          clockIdentifier = "12HourClock"
+          secondIncrement = 1 
+          useSeconds = false }
 
     type Msg =
     | SetTime of TimeSpan Nullable
     | SetHeader of string
     | SetMinuteIncrement of int
     | SetClockIdentifier of string
+    | SetSecondIncrement of int
+    | SetUseSeconds of bool
 
     let update (msg: Msg) (state: State) : State =
         match msg with
@@ -32,6 +38,8 @@ module TimePickerDemo =
         | SetHeader header -> { state with header = header }
         | SetMinuteIncrement m -> { state with minuteIncrement = m }
         | SetClockIdentifier ci -> { state with clockIdentifier = ci }
+        | SetSecondIncrement s -> { state with secondIncrement = s }
+        | SetUseSeconds b -> { state with useSeconds = b }
 
     let view (state: State) (dispatch) =
         StackPanel.create [
@@ -44,8 +52,10 @@ module TimePickerDemo =
                 TimePicker.create [
                     TimePicker.clockIdentifier state.clockIdentifier
                     TimePicker.minuteIncrement state.minuteIncrement
+                    TimePicker.secondIncrement state.secondIncrement
 
                     TimePicker.selectedTime state.time
+                    TimePicker.useSeconds state.useSeconds
 
                     TimePicker.onSelectedTimeChanged (
                         Msg.SetTime >> dispatch
@@ -68,6 +78,22 @@ module TimePickerDemo =
                     )
                 ]
                 
+                TextBlock.create [
+                    TextBlock.text "Seconds increment:"
+                ]
+
+                TextBox.create [
+                    TextBox.text (state.secondIncrement |> string)
+                    TextBox.onTextChanged (fun txt ->
+                        match Int32.TryParse txt with
+                        | true, i -> 
+                            i
+                            |> Msg.SetSecondIncrement
+                            |> dispatch
+                        | _ ->()
+                    )
+                ]
+
                 TextBox.create [
                     TextBox.watermark "Header"
                     TextBox.text state.header
@@ -96,6 +122,19 @@ module TimePickerDemo =
                     ComboBox.onSelectedItemChanged(
                         tryUnbox
                         >> Option.iter(Msg.SetClockIdentifier >> dispatch)
+                    )
+                ]
+
+                CheckBox.create [
+                    CheckBox.content "Use Seconds"
+                    CheckBox.isChecked state.useSeconds
+                    
+                    CheckBox.onIsCheckedChanged ((fun args ->
+                        state.useSeconds
+                        |> not 
+                        |> Msg.SetUseSeconds
+                        |> dispatch),
+                        SubPatchOptions.OnChangeOf state
                     )
                 ]
             ]

--- a/src/Avalonia.FuncUI/DSL/TimePicker.fs
+++ b/src/Avalonia.FuncUI/DSL/TimePicker.fs
@@ -17,9 +17,15 @@ module TimePicker =
         
         static member minuteIncrement<'t when 't :> TimePicker>(value: int) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<int>(TimePicker.MinuteIncrementProperty, value, ValueNone)
+
+        static member secondIncrement<'t when 't :> TimePicker>(value: int) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<int>(TimePicker.SecondIncrementProperty, value, ValueNone)
         
         static member selectedTime<'t when 't :> TimePicker>(value: Nullable<TimeSpan>) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<TimeSpan Nullable>(TimePicker.SelectedTimeProperty, value, ValueNone)
         
         static member onSelectedTimeChanged<'t when 't :> TimePicker>(func: Nullable<TimeSpan> -> unit, ?subPatchOptions) : IAttr<'t> =
             AttrBuilder<'t>.CreateSubscription<TimeSpan Nullable>(TimePicker.SelectedTimeProperty, func, ?subPatchOptions = subPatchOptions)
+
+        static member useSeconds<'t when 't :> TimePicker>(value: bool) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<bool>(TimePicker.UseSecondsProperty, value, ValueNone)

--- a/src/Avalonia.FuncUI/DSL/TimePickerPresenter.fs
+++ b/src/Avalonia.FuncUI/DSL/TimePickerPresenter.fs
@@ -16,6 +16,10 @@ module TimePickerPresenter =
         static member minuteIncrement<'t when 't :> TimePickerPresenter>(value: int) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<int>(TimePickerPresenter.MinuteIncrementProperty, value, ValueNone)
 
+        /// Gets or sets the second increment in the selector
+        static member secondIncrement<'t when 't :> TimePickerPresenter>(value: int) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<int>(TimePickerPresenter.SecondIncrementProperty, value, ValueNone)
+
         /// Gets or sets the current clock identifier, either 12HourClock or 24HourClock
         static member clockIdentifier<'t when 't :> TimePickerPresenter>(value: string) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<string>(TimePickerPresenter.ClockIdentifierProperty, value, ValueNone)
@@ -23,3 +27,7 @@ module TimePickerPresenter =
         /// Gets or sets the current time
         static member time<'t when 't :> TimePickerPresenter>(value: TimeSpan) : IAttr<'t> =
             AttrBuilder<'t>.CreateProperty<TimeSpan>(TimePickerPresenter.TimeProperty, value, ValueNone)
+
+        /// Gets or sets a value indicating whether seconds are displayed in the picker or not
+        static member useSeconds<'t when 't :> TimePickerPresenter>(value: bool) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<bool>(TimePickerPresenter.UseSecondsProperty, value, ValueNone)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <AvaloniaVersion>11.1.0</AvaloniaVersion>
+    <AvaloniaVersion>11.2.0</AvaloniaVersion>
     <FuncUIVersion>1.5.2</FuncUIVersion>
   </PropertyGroup>
 	


### PR DESCRIPTION
And update the TimePicker bindings to add the new 'seconds' related properties, including updating the control catalog to demo the feature.

This is new functionality in Avalonia 11.2, added in https://github.com/AvaloniaUI/Avalonia/pull/16079