### PR TITLE
Update Github actions to fix obsoletion warnings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
           8.x.x

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -17,10 +17,10 @@ jobs:
     - name: xCode
       run: sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer/
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
           8.x.x


### PR DESCRIPTION
refs these warnings in the CI

<img width="1466" height="177" alt="image" src="https://github.com/user-attachments/assets/2f9d715f-ac52-4b15-96ad-321583b96c48" />
