### PR TITLE
Update BenchmarkDotNet to 0.15.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,6 @@ src/docs/_public
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# BenchmarkDotNet artifacts
+src/Avalonia.FuncUI.Benchmarks/BenchmarkDotNet.Artifacts/**

--- a/src/Avalonia.FuncUI.Benchmarks/Avalonia.FuncUI.Benchmarks.fsproj
+++ b/src/Avalonia.FuncUI.Benchmarks/Avalonia.FuncUI.Benchmarks.fsproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
and add the benchmark artifacts to .gitignore

Nothing major here, I was just having a go at comparing the banchmarks on .NET 8 and .NET 10 and thought i'd update BDN to the latest version whilst doing it.

