### PR TITLE
Update version to 1.6.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,16 +12,16 @@ Create a new F# console application targeting .net 8 or higher.&#x20;
 
 ## Step 2: Packages
 
-&#x20;Reference the following packages [Avalonia.Desktop](https://www.nuget.org/packages/Avalonia.Desktop/11.1.0), [Avalonia.Themes.Fluent](https://www.nuget.org/packages/Avalonia.Themes.Fluent/11.1.0) and [Avalonia.FuncUI](https://www.nuget.org/packages/Avalonia.FuncUI/1.5.1).
+&#x20;Reference the following packages [Avalonia.Desktop](https://www.nuget.org/packages/Avalonia.Desktop/11.3.0), [Avalonia.Themes.Fluent](https://www.nuget.org/packages/Avalonia.Themes.Fluent/11.3.0) and [Avalonia.FuncUI](https://www.nuget.org/packages/Avalonia.FuncUI/1.6.0).
 
 {% tabs %}
 {% tab title="dotnet CLI" %}
 Run the following commands in your project directory:
 
 ```bash
-dotnet add package Avalonia.Desktop --version 11.1.0
-dotnet add package Avalonia.Themes.Fluent --version 11.1.0
-dotnet add package Avalonia.FuncUI --version 1.5.1
+dotnet add package Avalonia.Desktop --version 11.3.0
+dotnet add package Avalonia.Themes.Fluent --version 11.3.0
+dotnet add package Avalonia.FuncUI --version 1.6.0
 ```
 {% endtab %}
 
@@ -29,9 +29,9 @@ dotnet add package Avalonia.FuncUI --version 1.5.1
 Paste the following package references to your fsproject file:
 
 ```html
-<PackageReference Include="Avalonia.Desktop" Version="11.1.0" />
-<PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0" />
-<PackageReference Include="Avalonia.FuncUI" Version="1.5.1" />
+<PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
+<PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.0" />
+<PackageReference Include="Avalonia.FuncUI" Version="1.6.0" />
 ```
 {% endtab %}
 {% endtabs %}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <AvaloniaVersion>11.3.0</AvaloniaVersion>
-    <FuncUIVersion>1.5.2</FuncUIVersion>
+    <FuncUIVersion>1.6.0</FuncUIVersion>
   </PropertyGroup>
 	
   <!-- Common NuGet package properties -->


### PR DESCRIPTION
Update the docs to match, and to specify that Avalonia 11.3 should be used rather than 11.1

## Description

This updates to 1.6.0 to pick up all the updates for Avalonia 11.2/11.3, to be completed before merging the changes for Avalonia 12.

## Related Issue

refs https://github.com/fsprojects/Avalonia.FuncUI/issues/492
