### PR TITLE
Change the PR builds to use XCode 26.3

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: xCode
-      run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer/
+      run: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer/
 
     - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Description

The CI run for the Elmish update PR failed with 

<img width="1500" height="82" alt="image" src="https://github.com/user-attachments/assets/edbcac82-4745-4e92-aa6f-037d6d40fb4b" />

It looks like the CI updating .NET 10 from 10.0.5 to 10.0.6 has changed this, though I don't see it mentioned in the release notes.

So - try to update XCode again.


