### PR TITLE
Add bindings for TextOptions

### DIFF
--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -65,6 +65,7 @@
     <Compile Include="DSL\Base\TextPresenter.fs" />
     <Compile Include="DSL\Base\Animatable.fs" />
     <Compile Include="DSL\Base\RenderOptions.fs" />
+    <Compile Include="DSL\Base\TextOptions.fs" />
     <Compile Include="DSL\Primitives\AdornerLayer.fs" />
     <Compile Include="DSL\Primitives\OverlayLayer.fs" />
     <Compile Include="DSL\Primitives\TemplatedControl.fs" />

--- a/src/Avalonia.FuncUI/DSL/Base/RenderOptions.fs
+++ b/src/Avalonia.FuncUI/DSL/Base/RenderOptions.fs
@@ -38,15 +38,5 @@ module RenderOptions =
                 comparer = ValueNone
             )
 
-        static member textRenderingMode<'t when 't :> Visual>(mode: TextRenderingMode) : IAttr<'t> =
-            AttrBuilder<'t>.CreateProperty<TextRenderingMode>(
-                name = nameof TextRenderingMode,
-                value = mode,
-                getter = ValueSome RenderOptions.GetTextRenderingMode,
-                setter = ValueSome RenderOptions.SetTextRenderingMode,
-                comparer = ValueNone
-            )
-
-
     type RenderOptions with
         end

--- a/src/Avalonia.FuncUI/DSL/Base/TextOptions.fs
+++ b/src/Avalonia.FuncUI/DSL/Base/TextOptions.fs
@@ -1,0 +1,47 @@
+namespace Avalonia.FuncUI.DSL
+
+open Avalonia
+
+[<AutoOpen>]
+module TextOptions =
+    open Avalonia.Media
+    open Avalonia.FuncUI.Types
+    open Avalonia.FuncUI.Builder
+
+    type Visual with
+
+        static member baselinePixelAlignment<'t when 't :> Visual>(alignnment: BaselinePixelAlignment) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<BaselinePixelAlignment>(
+                name = nameof BaselinePixelAlignment,
+                value = alignnment,
+                getter = ValueSome TextOptions.GetBaselinePixelAlignment,
+                setter = ValueSome TextOptions.SetBaselinePixelAlignment,
+                comparer = ValueNone
+            )
+
+        static member textHintingMode<'t when 't :> Visual>(mode: TextHintingMode) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<TextHintingMode>(
+                name = nameof TextHintingMode,
+                value = mode,
+                getter = ValueSome TextOptions.GetTextHintingMode,
+                setter = ValueSome TextOptions.SetTextHintingMode,
+                comparer = ValueNone
+            )
+
+        static member textOptions<'t when 't :> Visual>(options: TextOptions) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<TextOptions>(
+                name = nameof TextOptions,
+                value = options,
+                getter = ValueSome TextOptions.GetTextOptions,
+                setter = ValueSome TextOptions.SetTextOptions,
+                comparer = ValueNone
+            )
+
+        static member textRenderingMode<'t when 't :> Visual>(mode: TextRenderingMode) : IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<TextRenderingMode>(
+                name = nameof TextRenderingMode,
+                value = mode,
+                getter = ValueSome TextOptions.GetTextRenderingMode,
+                setter = ValueSome TextOptions.SetTextRenderingMode,
+                comparer = ValueNone
+            )


### PR DESCRIPTION
## Description

Avalonia 12 added a new 'TextOptions' class with text options related settings.

The existing TextRenderingMode property on RenderOptions was deprecated, and the TextOptions version is recommended instead. The old and new functions are implemented here as extensions on Visual, so moving textRenderingMode might be transparent to callers.

## Related Issue

refs the warnings mentioned in https://github.com/fsprojects/Avalonia.FuncUI/issues/497#issuecomment-4255409997

Avalonia changes: https://github.com/AvaloniaUI/Avalonia/pull/20107
