### PR TITLE
Add bindings for GroupBox

### DIFF
--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog.fsproj
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog.fsproj
@@ -30,6 +30,7 @@
         <Compile Include="Views\Tabs\DragDropDemo.fs" />
         <Compile Include="Views\Tabs\AttachedEventDemo.fs" />
         <Compile Include="Views\Tabs\HyperlinkButtonDemo.fs" />
+        <Compile Include="Views\Tabs\GroupBoxDemo.fs" />
         <Compile Include="Views\MainView.fs" />
 		<Compile Include="ControlCatalog.fs" />
         <AvaloniaResource Include="**\*.xaml" />

--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/MainView.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/MainView.fs
@@ -65,6 +65,10 @@ module MainView =
                     TabItem.content (ViewBuilder.Create<GridSplitterDemo.Host>([]))
                 ]
                 TabItem.create [
+                    TabItem.header "GroupBox Demo"
+                    TabItem.content (ViewBuilder.Create<GroupBoxDemo.Host>([]))
+                ]
+                TabItem.create [
                     TabItem.header "HyperlinkButton Demo"
                     TabItem.content (ViewBuilder.Create<HyperlinkButtonDemo.Host>([]))
                 ]

--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/Tabs/GroupBoxDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog/Views/Tabs/GroupBoxDemo.fs
@@ -1,0 +1,37 @@
+﻿namespace Avalonia.FuncUI.ControlCatalog.Views
+
+open Elmish
+open Avalonia.Controls
+open Avalonia.FuncUI.DSL
+open Avalonia.FuncUI
+open Avalonia.FuncUI.Elmish
+
+module GroupBoxDemo = 
+
+    let update _ _ = ()
+
+    let view _ _ =
+        StackPanel.create [
+            StackPanel.children [
+                TextBlock.create [
+                    TextBlock.text "GroupBox samples"
+                ]
+
+                GroupBox.create [
+                    GroupBox.header "This is a GroupBox"
+                    GroupBox.content(
+                        TextBlock.create [
+                            TextBlock.text "Essentially a restyled HeaderedContentControl"
+                        ]
+                    )
+                ]
+            ]
+        ]
+
+    type Host() as this =
+        inherit Hosts.HostControl()
+        do
+            Elmish.Program.mkSimple id update view
+            |> Program.withHost this
+            |> Program.withConsoleTrace
+            |> Program.run

--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -179,6 +179,7 @@
     <Compile Include="DSL\SelectableTextBlock.fs" />
     <Compile Include="DSL\PathIcon.fs" />
     <Compile Include="DSL\DragDrop.fs" />
+    <Compile Include="DSL\GroupBox.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Avalonia.FuncUI/DSL/GroupBox.fs
+++ b/src/Avalonia.FuncUI/DSL/GroupBox.fs
@@ -1,0 +1,9 @@
+namespace Avalonia.FuncUI.DSL
+
+[<AutoOpen>]
+module GroupBox =
+    open Avalonia.FuncUI.Types
+    open Avalonia.Controls
+
+    let create (attrs: IAttr<GroupBox> list): IView<GroupBox> =
+        ViewBuilder.Create<GroupBox>(attrs)


### PR DESCRIPTION
And add a sample to the control catalog.

GroupBox was added in Avalonia 12.

Note: GroupBox itself is a subclass of HeaderedContentControl with no additional properties - the difference is in the styling - so there's not much to add here

## Description

<!-- Please describe the changes this PR introduces. -->

## Related Issue

fixes #507
refs #497 


