### PR TITLE
Modify focus events for TextBox B

### DIFF
--- a/docs/common-questions.md
+++ b/docs/common-questions.md
@@ -131,8 +131,8 @@ Component.create ("view", fun ctx ->
             ]
             TextBox.create [
                 TextBox.init textBoxB.Set
-                TextBox.onGotFocus (fun _ -> textBoxAFocus.Set true)
-                TextBox.onLostFocus (fun _ -> textBoxAFocus.Set false)
+                TextBox.onGotFocus (fun _ -> textBoxBFocus.Set true)
+                TextBox.onLostFocus (fun _ -> textBoxBFocus.Set false)
             ]
             StackPanel.create [
                 StackPanel.orientation Orientation.Horizontal


### PR DESCRIPTION
Updated focus handling for TextBox B to set focus state. it's a 2 character documentation change that doesn't have any tests associated with it, most likely, won't affect builds, etc. I don't see an advantage of going through the ceremony of the checklist items, as if it were a real code change.  
