### PR TITLE
Use XCode 26.5 for CI builds

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -11,11 +11,11 @@ concurrency:
 jobs:
   build:
 
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
     - name: xCode
-      run: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer/
+      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer/
 
     - uses: actions/checkout@v6
 


### PR DESCRIPTION
refs the CI failre for #510 

<img width="2140" height="128" alt="image" src="https://github.com/user-attachments/assets/02f00dd4-e420-4db8-864b-740d604f27f2" />

Looks like the build agent updating to a newer .NET SDK means that it requires a newer XCode version.