### PR TITLE
Set version to 2.0.0-preview2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Create a new F# console application targeting .net 8 or higher.&#x20;
 
 ## Step 2: Packages
 
-&#x20;Reference the following packages [Avalonia.Desktop](https://www.nuget.org/packages/Avalonia.Desktop/12.0.0), [Avalonia.Themes.Fluent](https://www.nuget.org/packages/Avalonia.Themes.Fluent/12.0.0) and [Avalonia.FuncUI](https://www.nuget.org/packages/Avalonia.FuncUI/2.0.0-preview1).
+&#x20;Reference the following packages [Avalonia.Desktop](https://www.nuget.org/packages/Avalonia.Desktop/12.0.0), [Avalonia.Themes.Fluent](https://www.nuget.org/packages/Avalonia.Themes.Fluent/12.0.0) and [Avalonia.FuncUI](https://www.nuget.org/packages/Avalonia.FuncUI/2.0.0-preview2).
 
 {% tabs %}
 {% tab title="dotnet CLI" %}
@@ -21,7 +21,7 @@ Run the following commands in your project directory:
 ```bash
 dotnet add package Avalonia.Desktop --version 12.1.0
 dotnet add package Avalonia.Themes.Fluent --version 12.1.0
-dotnet add package Avalonia.FuncUI --version 2.0.0-preview1
+dotnet add package Avalonia.FuncUI --version 2.0.0-preview2
 ```
 {% endtab %}
 
@@ -31,7 +31,7 @@ Paste the following package references to your fsproject file:
 ```html
 <PackageReference Include="Avalonia.Desktop" Version="12.1.0" />
 <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.0" />
-<PackageReference Include="Avalonia.FuncUI" Version="2.0.0-preview1" />
+<PackageReference Include="Avalonia.FuncUI" Version="2.0.0-preview2" />
 ```
 {% endtab %}
 {% endtabs %}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <AvaloniaVersion>12.1.0</AvaloniaVersion>
-    <FuncUIVersion>2.0.0-preview1</FuncUIVersion>
+    <FuncUIVersion>2.0.0-preview2</FuncUIVersion>
   </PropertyGroup>
 	
   <!-- Common NuGet package properties -->


### PR DESCRIPTION
Just wondering whether updating from Avalonia 12.0 to 12.1 makes it worth doing another preview build?