### PR TITLE
Fix the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ Please reach out to contact@voyonic-systmes.de if you need a commercial support 
 
 # Star History 
 
-<a href="https://star-history.com/#fsprojects/Avalonia.FuncUI&Date">
+<a href="https://star-history.dera.page/#fsprojects/Avalonia.FuncUI&type=Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=fsprojects/Avalonia.FuncUI&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=fsprojects/Avalonia.FuncUI&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=fsprojects/Avalonia.FuncUI&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=fsprojects/Avalonia.FuncUI&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=fsprojects/Avalonia.FuncUI&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=fsprojects/Avalonia.FuncUI&type=Date" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change points it to the new star-history domain, which uses an alternative data source that requires no API token, so the chart works again for everyone.